### PR TITLE
Updated src/imagenes/reducir.py to do faster image conversion using PIL

### DIFF
--- a/src/imagenes/reducir.py
+++ b/src/imagenes/reducir.py
@@ -25,7 +25,7 @@ def scaleImage(frompath, topath, scale_factor):
     
     # pull out the original dimensions and calculate resized dimensions
     width, height = im.size 
-    resize_tuple  = (width * scale_ratio, height * scale_ratio)
+    resize_tuple  = (int(width * scale_ratio), int(height * scale_ratio))
     
     # resize and save at new destination
     output_image = im.resize(resize_tuple)


### PR DESCRIPTION
### Image conversion using PIL

As suggested in the issue #40 , now we use **PIL** package in `src/imagenes/reducir.py` to do image conversion for us.

Earlier, image conversion was done by
 
1. Calling the external `convert` system call for each image
2. After resize the image was checked for errors
3. In case of no errors image was saved in the dist folder

This was slower and not efficient.

Now.

1. PIL library is installed and we call the Image class
2. Height and width parameters are identified for each image
3. Resizing is done internally based on the scaling percentage
4. New image is saved in the dist folder
5. In case image is not found we log the error.

The main conversion method looks like this

````
import Image

def scaleImage(frompath, topath, scale_factor):
    """
    Reduces the size ofan image by the scale_factor using the PIL library
    """
    scale_ratio = scale_factor / 100 # since scale_factor is in percentage
    try:
        im = Image.open(frompath)
    except IOError:
        logger.warning("Couldn't read image at %s" % frompath)
        return -1
    
    # pull out the original dimensions and calculate resized dimensions
    width, height = im.size 
    resize_tuple  = (width * scale_ratio, height * scale_ratio)
    
    # resize and save at new destination
    output_image = im.resize(resize_tuple)
    output_image.save(topath)
    logger.info("Success! Resized image saved at %s" % topath)
    
    return 0
````
Here we call the method to scale images..

````

def run(verbose):
    ...
    # scale image using PIL
    status = scaleImage(frompath=frompath, topath=topath, scale_factor=escl)
                
````