### PR TITLE
Replace old CDPedia Launchpad repo links with new GitHub repo link

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -5,6 +5,7 @@ más participaron:
  - Antonio Lenton
  - Alejandro David Weil
  - Alejandro J. Cura
+ - Berenice A. Larsen Pereyra
  - Claudio D. Freire
  - Diego Mascialino
  - Ezequiel Diaz Marquez
@@ -28,5 +29,4 @@ más participaron:
  - Santiago Piccinini
  - Sebastian Farioli
  - Zuzel Vera Pacheco
- - Berenice A. Larsen Pereyra
 

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -28,4 +28,5 @@ más participaron:
  - Santiago Piccinini
  - Sebastian Farioli
  - Zuzel Vera Pacheco
+ - Berenice A. Larsen Pereyra
 

--- a/generar.py
+++ b/generar.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 from __future__ import with_statement, print_function
 

--- a/src/imagenes/calcular.py
+++ b/src/imagenes/calcular.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 """
 Busca las imágenes en los htmls que están en el archivo de preprocesados, y

--- a/src/imagenes/extract.py
+++ b/src/imagenes/extract.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 """Extract images from the HTMLs.
 

--- a/src/web/web_app.py
+++ b/src/web/web_app.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 
 import codecs

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 """Tests for the 'extract' module."""
 

--- a/tests/test_to3dirs.py
+++ b/tests/test_to3dirs.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 """Tests for the 'to3dirs' module."""
 

--- a/utilities/cdpetron.py
+++ b/utilities/cdpetron.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 from __future__ import print_function
 

--- a/utilities/list_articles_by_namespaces.py
+++ b/utilities/list_articles_by_namespaces.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  https://launchpad.net/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 """Generate the list of articles inside some Namespaces."""
 

--- a/web/index.html
+++ b/web/index.html
@@ -183,7 +183,7 @@
    <div class="container">
     <p>Seguinos en Twitter
     &nbsp;<a href="http://twitter.com/PythonArgentina">@PythonArgentina</a></p>
-    <p><a href="http://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> <a href="https://launchpad.net/~cdpedistas">Los CDPedistas</a>
+    <p><a href="http://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> <a href="https://raw.githubusercontent.com/PyAr/CDPedia/master/AUTHORS.txt">Los CDPedistas</a>
    </div>
   </footer>
  </body>


### PR DESCRIPTION
Fix #187 