### PR TITLE
add parameter to cdpetron to include specifc articles

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -16,6 +16,7 @@ más participaron:
  - Guillermo Gonzalez
  - Hernán Olivera
  - Hugo Ruscitti
+ - Laureano Silva
  - Leito Monk
  - Lucio Torre
  - Marcos Dione

--- a/utilities/cdpetron.py
+++ b/utilities/cdpetron.py
@@ -154,7 +154,6 @@ def _call_scrapper(branch_dir, language, dump_lang_dir, articles_file, test=Fals
         branch_dir, articles_file, language, DUMP_ARTICLES, namespaces_path)
     if test:
         cmd += " " + str(TEST_LIMIT_SCRAP)
-    print(cmd)
     res = os.system(cmd)
     if res != 0:
         logger.error("Bad result code from scrapping: %r", res)

--- a/utilities/cdpetron.py
+++ b/utilities/cdpetron.py
@@ -186,7 +186,7 @@ def scrap_pages(branch_dir, language, dump_lang_dir, test):
 
 
 def scrap_extra_pages(branch_dir, language, dump_lang_dir, extra_pages):
-    """scrap extra pages defined in a text file"""
+    """Scrap extra pages defined in a text file."""
     extra_pages_file = os.path.join(branch_dir, extra_pages)
     _call_scrapper(branch_dir, language, dump_lang_dir, extra_pages_file)
 

--- a/utilities/cdpetron.py
+++ b/utilities/cdpetron.py
@@ -144,6 +144,24 @@ def get_lists(branch_dir, language, config, test):
     return gendate
 
 
+def _call_scrapper(branch_dir, language, dump_lang_dir, articles_file, test=False):
+    """Prepare the command and run scraper.py."""
+
+    logger.info("Let's scrap (with limit=%s)", test)
+    assert os.getcwd() == dump_lang_dir
+    namespaces_path = os.path.join(dump_lang_dir, DUMP_RESOURCES, NAMESPACES)
+    cmd = "python %s/utilities/scraper.py %s %s %s %s" % (
+        branch_dir, articles_file, language, DUMP_ARTICLES, namespaces_path)
+    if test:
+        cmd += " " + str(TEST_LIMIT_SCRAP)
+    print(cmd)
+    res = os.system(cmd)
+    if res != 0:
+        logger.error("Bad result code from scrapping: %r", res)
+        logger.error("Quitting, no point in continue")
+        exit()
+
+
 def scrap_pages(branch_dir, language, dump_lang_dir, test):
     """Get the pages from wikipedia."""
     articles_dir = os.path.join(dump_lang_dir, DUMP_ARTICLES)
@@ -152,18 +170,7 @@ def scrap_pages(branch_dir, language, dump_lang_dir, test):
         shutil.rmtree(articles_dir)
     os.mkdir(articles_dir)
 
-    logger.info("Let's scrap (with limit=%s)", test)
-    assert os.getcwd() == dump_lang_dir
-    namespaces_path = os.path.join(dump_lang_dir, DUMP_RESOURCES, NAMESPACES)
-    cmd = "python %s/utilities/scraper.py %s %s %s %s" % (
-        branch_dir, ART_ALL, language, DUMP_ARTICLES, namespaces_path)
-    if test:
-        cmd += " " + str(TEST_LIMIT_SCRAP)
-    res = os.system(cmd)
-    if res != 0:
-        logger.error("Bad result code from scrapping: %r", res)
-        logger.error("Quitting, no point in continue")
-        exit()
+    _call_scrapper(branch_dir, language, dump_lang_dir, ART_ALL, test)
 
     logger.info("Checking scraped size")
     total = os.stat(articles_dir).st_size
@@ -181,17 +188,8 @@ def scrap_pages(branch_dir, language, dump_lang_dir, test):
 
 def scrap_extra_pages(branch_dir, language, dump_lang_dir, extra_pages):
     """scrap extra pages defined in a text file"""
-    logger.info("Let's scrap selected extra pages")
-    assert os.getcwd() == dump_lang_dir
     extra_pages_file = os.path.join(branch_dir, extra_pages)
-    namespaces_path = os.path.join(dump_lang_dir, DUMP_RESOURCES, NAMESPACES)
-    cmd = "python %s/utilities/scraper.py %s %s %s %s" % (
-        branch_dir, extra_pages_file, language, DUMP_ARTICLES, namespaces_path)
-    res = os.system(cmd)
-    if res != 0:
-        logger.error("Bad result code from scrapping: %r", res)
-        logger.error("Quitting, no point in continue")
-        exit()
+    _call_scrapper(branch_dir, language, dump_lang_dir, extra_pages_file)
 
 
 def scrap_portals(dump_lang_dir, language, lang_config):

--- a/utilities/cdpetron.py
+++ b/utilities/cdpetron.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
                         help="A directory to store all articles and images.")
     parser.add_argument("language",
                         help="The two-letters language name.")
-    parser.add_argument("--extra_pages",
+    parser.add_argument("--extra-pages",
                         help="file with extra pages to be included in the image.")
     args = parser.parse_args()
 

--- a/utilities/cdpetron.py
+++ b/utilities/cdpetron.py
@@ -179,6 +179,21 @@ def scrap_pages(branch_dir, language, dump_lang_dir, test):
     logger.info("Total size of scraped articles: %d MB", total // 1024 ** 2)
 
 
+def scrap_extra_pages(branch_dir, language, dump_lang_dir, extra_pages):
+    """scrap extra pages defined in a text file"""
+    logger.info("Let's scrap selected extra pages")
+    assert os.getcwd() == dump_lang_dir
+    extra_pages_file = os.path.join(branch_dir, extra_pages)
+    namespaces_path = os.path.join(dump_lang_dir, DUMP_RESOURCES, NAMESPACES)
+    cmd = "python %s/utilities/scraper.py %s %s %s %s" % (
+        branch_dir, extra_pages_file, language, DUMP_ARTICLES, namespaces_path)
+    res = os.system(cmd)
+    if res != 0:
+        logger.error("Bad result code from scrapping: %r", res)
+        logger.error("Quitting, no point in continue")
+        exit()
+
+
 def scrap_portals(dump_lang_dir, language, lang_config):
     """Get the portal index and scrap it."""
     # always create the resources directory
@@ -243,7 +258,7 @@ def clean(branch_dir, dump_dir, keep_processed):
 
 
 def main(branch_dir, dump_dir, language, lang_config, imag_config,
-         nolists, noscrap, noclean, image_type, test):
+         nolists, noscrap, noclean, image_type, test, extra_pages):
     """Main entry point."""
     logger.info("Branch directory: %r", branch_dir)
     logger.info("Dump directory: %r", dump_dir)
@@ -271,6 +286,9 @@ def main(branch_dir, dump_dir, language, lang_config, imag_config,
     if not noscrap:
         scrap_portals(dump_lang_dir, language, lang_config)
         scrap_pages(branch_dir, language, dump_lang_dir, test)
+
+    if extra_pages:
+        scrap_extra_pages(branch_dir, language, dump_lang_dir, extra_pages)
 
     os.chdir(branch_dir)
 
@@ -315,6 +333,8 @@ if __name__ == "__main__":
                         help="A directory to store all articles and images.")
     parser.add_argument("language",
                         help="The two-letters language name.")
+    parser.add_argument("--extra_pages",
+                        help="file with extra pages to be included in the image.")
     args = parser.parse_args()
 
     if args.no_clean and not args.image_type:
@@ -371,4 +391,4 @@ if __name__ == "__main__":
 
     main(branch_dir, dump_dir, args.language, lang_config, imag_config,
          nolists=args.no_lists, noscrap=args.no_scrap,
-         noclean=args.no_clean, image_type=args.image_type, test=args.test_mode)
+         noclean=args.no_clean, image_type=args.image_type, test=args.test_mode, extra_pages=args.extra_pages)


### PR DESCRIPTION
fix #181 

use:

`utilities/cdpetron.py  --test-mode --no-list --no-scrap . /tmp/dump es --extra_pages "file.txt"`

being "file.txt" a file with a list of wikipedia article titles that we want to include. Also the file has to be in the branch dir

