### PR TITLE
Remove a tags without href attrib while fixing links

### DIFF
--- a/src/imagenes/extract.py
+++ b/src/imagenes/extract.py
@@ -300,7 +300,10 @@ class ImageParser(object):
 
         link = tag.attrs.get('href')
 
-        if link.startswith("http://"):
+        if not link:
+            tag.unwrap()
+            return
+        elif link.startswith("http://"):
             return
         elif not link.startswith(SEPLINK):
             # not a classic article link, leave it as is


### PR DESCRIPTION
Remove `<a>` tags if `href` attribute is not present, preserving inner text in tree (if any).