### PR TITLE
Update HTMLCleaner

### DIFF
--- a/resources/static/css/cdpedia.css
+++ b/resources/static/css/cdpedia.css
@@ -7,6 +7,10 @@
 	overflow: hidden;
 }
 
+#toc {
+    display: table;
+}
+
 ul#navegacionBody {
 	list-style-type: none;
 	list-style-image: none;

--- a/resources/static/skins/css/Vector.css
+++ b/resources/static/skins/css/Vector.css
@@ -16,8 +16,8 @@ margin-top: 0 !important;
 
 #coordinates {
  position: absolute;
- top: 0em;
- right: 0em;
+ top: -3.5em;
+ right: 2.5em;
  float: right;
  margin: 0.0em;
  padding: 0.0em;

--- a/resources/static/skins/css/main.css
+++ b/resources/static/skins/css/main.css
@@ -625,6 +625,7 @@ body.ltr #footer #footer-places {
  */
 #content {
 	line-height: 1.5em;
+	overflow-y: auto;
 }
 #bodyContent {
 	font-size: 0.8em;
@@ -682,6 +683,7 @@ h6 {
 	padding-bottom: .17em;
 	border-bottom: 1px solid #aaa;
 	width: auto;
+	overflow: hidden;
 }
 h1 { font-size: 188%; }
 h1 .editsection { font-size: 53%; }

--- a/src/preprocessing/preprocessors.py
+++ b/src/preprocessing/preprocessors.py
@@ -290,6 +290,23 @@ class Length(_Processor):
 class HTMLCleaner(_Processor):
     """Remove different HTML parts or sections."""
 
+    target_tags = [
+        # (description, action, tag[, attr_key, attr_val]*)
+        ('edit_section', 'clear', 'span', 'class', 'mw-editsection'),
+        ('error_notice', 'remove', 'span', 'class', 'error'),
+        ('hidden_categories', 'remove', 'div', 'id', 'mw-hidden-catlinks'),
+        ('hidden_subtitle', 'remove', 'div', 'id', 'siteSub'),
+        ('img_srcset', 'pop_srcset', 'img', 'srcset', True),
+        ('inline_alert', 'remove_inline_alert', 'sup'),
+        ('inline_math', 'clear', 'span', 'class', 'mwe-math-mathml-inline'),
+        ('jump_link_search', 'remove', 'a', 'class', 'mw-jump-link', 'href', '#p-search'),
+        ('jump_link_toc', 'remove', 'a', 'class', 'mw-jump-link', 'href', '#mw-head'),
+        ('message_box', 'clear', 'table', 'class', 'ambox'),
+        ('not_last_version', 'clear', 'div', 'id', 'contentSub'),
+        ('print_footer', 'remove', 'div', 'class', 'printfooter'),
+        ('special_link', 'unwrap_link', 'a','href', True),  # keep after other `a` tags
+    ]
+
     # if the first column found in a link, replace it by its text (keeping stats
     # using the second column)
     unwrap_links = [
@@ -301,95 +318,15 @@ class HTMLCleaner(_Processor):
     def __init__(self):
         super(HTMLCleaner, self).__init__()
         self.name = "HTMLCleaner"
+        self.targets = self._build_targets()
         self.stats = collections.Counter()
 
     def __call__(self, wikifile):
         soup = bs4.BeautifulSoup(wikifile.html, features='html.parser', from_encoding='utf8')
 
-        # remove text and links of 'not last version'
-        tag = soup.find('div', id='contentSub')
-        if tag is not None:
-            tag.clear()
-            self.stats['notlastversion'] += 1
-
-        # remove edit section
-        sections = soup.find_all('span', class_="mw-editsection")
-        self.stats['edit_sections'] += len(sections)
-        for tag in sections:
-            tag.clear()
-
-        # remove ambox (reference needed) section
-        sections = soup.find_all('table', class_="ambox")
-        self.stats['ambox'] += len(sections)
-        for tag in sections:
-            tag.clear()
-
-        # remove inline math
-        sections = soup.find_all('span', class_="mwe-math-mathml-inline")
-        self.stats['inline_math'] += len(sections)
-        for tag in sections:
-            tag.clear()
-
-        # remove srcset attribute from img tags
-        sections = soup.find_all('img', srcset=True)
-        self.stats['img_srcset'] += len(sections)
-        for tag in sections:
-            tag.attrs.pop('srcset')
-
-        # remove some links (but keeping their text)
-        for a_tag in soup.find_all('a'):
-            try:
-                href = a_tag['href']
-            except KeyError:
-                # no link
-                continue
-
-            for searchable, stat_key in self.unwrap_links:
-                if searchable in href:
-                    # special link, keep stat and replace it by the text
-                    self.stats[stat_key] += 1
-                    a_tag.unwrap()
-                    break
-
-        # remove hidden subtitle
-        tag = soup.find('div', id='siteSub')
-        if tag is not None:
-            tag.extract()
-            self.stats['hidden_subtitle'] += 1
-
-        # remove toc jump link
-        tag = soup.find('a', class_='mw-jump-link', href='#mw-head')
-        if tag is not None:
-            tag.extract()
-            self.stats['jump_links'] += 1
-
-        # remove search jump link
-        tag = soup.find('a', class_='mw-jump-link', href='#p-search')
-        if tag is not None:
-            tag.extract()
-            self.stats['jump_links'] += 1
-
-        # remove inline alerts (bracketed superscript with italic text)
-        for tag in soup.find_all('sup'):
-            children = tag.children
-            try:
-                if next(children) == '[' and next(children).name == 'i':
-                    tag.extract()
-                    self.stats['inline_alerts'] += 1
-            except StopIteration:
-                continue
-
-        # remove printfooter
-        tag = soup.find('div', class_='printfooter')
-        if tag is not None:
-            tag.extract()
-            self.stats['print_footer'] += 1
-
-        # remove hidden categories section
-        tag = soup.find('div', id='mw-hidden-catlinks')
-        if tag is not None:
-            tag.extract()
-            self.stats['hidden_categories'] += 1
+        # process tags
+        for tag, action, descr in self._find_tags(soup):
+            action(tag, descr)
 
         # remove comments
         for tag in soup(text=True):
@@ -397,14 +334,90 @@ class HTMLCleaner(_Processor):
                 tag.extract()
                 self.stats['comments'] += 1
 
-        # remove mediawiki parsing error red notices
-        for tag in soup('span', class_='error'):
-            tag.extract()
-            self.stats['parsing_error_notices'] += 1
-
         # fix original html and return no score at all
         wikifile.html = str(soup)
         return (0, [])
+
+    def _build_targets(self):
+        """Put info of targeted tags into a conveniently structured dict."""
+        targets = dict()
+        for target in self.target_tags:
+            descr, action, tag_name = target[:3]
+            i = iter(target[3:])
+            attrs = tuple(zip(i, i))
+            info = (attrs, getattr(self, action), descr)
+            try:
+                targets[tag_name].append(info)
+            except KeyError:
+                targets[tag_name] = [info]
+        return targets
+
+    def _find_tags(self, soup):
+        tags = []
+        for elem in soup.descendants:
+            try:
+                action, descr = self._get_action(elem)
+            except ValueError:
+                continue
+            tags.append((elem, action, descr))
+        return tags
+
+    def _get_action(self, tag):
+        try:
+            for attrs, action, descr in self.targets[tag.name]:
+                if self._match_conditions(tag, attrs):
+                    return action, descr
+        except KeyError:
+            pass
+        raise ValueError('Not a targeted tag.')
+
+    def _match_conditions(self, tag, attrs):
+        """Check if tag matches conditions for running action."""
+        for k, v in attrs:
+            if v is True:
+                if not tag.has_attr(k):
+                    return False
+                continue
+            if v not in tag.get_attribute_list(k):
+                return False
+        if tag.parent is None:  # parent removed
+            return False
+        return True
+
+    def clear(self, tag, descr):
+        """Remove tag inner content from tree."""
+        tag.clear()
+        self.stats[descr] += 1
+
+    def remove(self, tag, descr):
+        """Remove tag and its content from tree."""
+        tag.extract()
+        self.stats[descr] += 1
+
+    def unwrap_link(self, tag, descr):
+        """Remove special link tags but keep original text."""
+        href = tag.attrs['href']
+        for searchable, stat_key in self.unwrap_links:
+            if searchable in href and tag.parent:
+                # special link, keep stat and replace it by the text
+                self.stats[stat_key] += 1
+                tag.unwrap()
+                break
+
+    def pop_srcset(self, tag, descr):
+        """Remove srcset attribute from tag."""
+        tag.attrs.pop('srcset')
+        self.stats[descr] += 1
+
+    def remove_inline_alert(self, tag, descr):
+        """Remove bracketed superscript with italic text inline alerts."""
+        children = tag.children
+        try:
+            if next(children) == '[' and next(children).name == 'i':
+                tag.extract()
+                self.stats[descr] += 1
+        except StopIteration:
+            return
 
 
 # Classes that will be used for preprocessing each page,

--- a/src/preprocessing/preprocessors.py
+++ b/src/preprocessing/preprocessors.py
@@ -358,6 +358,18 @@ class HTMLCleaner(_Processor):
             tag.extract()
             self.stats['hidden_subtitle'] += 1
 
+        # remove toc jump link
+        tag = soup.find('a', class_='mw-jump-link', href='#mw-head')
+        if tag is not None:
+            tag.extract()
+            self.stats['jump_links'] += 1
+
+        # remove search jump link
+        tag = soup.find('a', class_='mw-jump-link', href='#p-search')
+        if tag is not None:
+            tag.extract()
+            self.stats['jump_links'] += 1
+
         # remove inline alerts (bracketed superscript with italic text)
         for tag in soup.find_all('sup'):
             children = tag.children

--- a/src/preprocessing/preprocessors.py
+++ b/src/preprocessing/preprocessors.py
@@ -386,8 +386,7 @@ class HTMLCleaner(_Processor):
             self.stats['print_footer'] += 1
 
         # remove hidden categories section
-        tag = soup.find('div', id='mw-hidden-catlinks')
-        if tag is not None:
+        for tag in soup.find_all('div', id='mw-hidden-catlinks'):
             tag.extract()
             self.stats['hidden_categories'] += 1
 

--- a/src/preprocessing/preprocessors.py
+++ b/src/preprocessing/preprocessors.py
@@ -45,7 +45,6 @@ import re
 from urllib2 import unquote
 
 import bs4
-from bs4 import Comment
 
 import config
 
@@ -170,7 +169,7 @@ class VIPArticles(_Processor):
 
     def __init__(self):
         super(VIPArticles, self).__init__()
-        self.nombre = "VIPArticles"
+        self.name = "VIPArticles"
         self.stats = collections.Counter()
 
     def __call__(self, wikifile):
@@ -188,7 +187,7 @@ class OmitRedirects(_Processor):
 
     def __init__(self):
         super(OmitRedirects, self).__init__()
-        self.nombre = "Redirects"
+        self.name = "Redirects"
         self.output = codecs.open(config.LOG_REDIRECTS, "a", "utf-8")
         self.stats = collections.Counter()
 
@@ -301,7 +300,7 @@ class HTMLCleaner(_Processor):
 
     def __init__(self):
         super(HTMLCleaner, self).__init__()
-        self.nombre = "HTMLCleaner"
+        self.name = "HTMLCleaner"
         self.stats = collections.Counter()
 
     def __call__(self, wikifile):
@@ -394,7 +393,7 @@ class HTMLCleaner(_Processor):
 
         # remove comments
         for tag in soup(text=True):
-            if isinstance(tag, Comment):
+            if isinstance(tag, bs4.Comment):
                 tag.extract()
                 self.stats['comments'] += 1
 

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf8 -*-
 
-# Copyright 2017 CDPedistas (see AUTHORS.txt)
+# Copyright 2017-2020 CDPedistas (see AUTHORS.txt)
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For further info, check  http://code.google.com/p/cdpedia/
+# For further info, check  https://github.com/PyAr/CDPedia/
 
 """Tests for the src.preprocessing.preprocessors module."""
 

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -96,6 +96,17 @@ class HTMLCleanerTestCase(unittest.TestCase):
         self.assertEqual(result, (0, []))
         self.assertEqual(html_fixed, wikifile.html)
 
+    def test_remove_jump_links(self):
+        text1 = '<a class="mw-jump-link" href="#mw-head">'
+        text2 = '<a class="mw-jump-link" href="#p-search">'
+        assert text1 in self.article_1
+        assert text2 in self.article_1
+        wikifile = FakeWikiFile(self.article_1)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        assert text1 not in wikifile.html
+        assert text2 not in wikifile.html
+
     def test_remove_inline_alerts(self):
         # Make shure references like `[1]` are not touched.
         html = ('<p>Foo<sup>[<i><a href="link">spam spam<a></i>]</sup> '

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf8 -*-
 
 # Copyright 2017 CDPedistas (see AUTHORS.txt)
 #
@@ -18,8 +19,8 @@
 
 """Tests for the src.preprocessing.preprocessors module."""
 
-import unittest
 import os
+import unittest
 
 from src.preprocessing.preprocessors import HTMLCleaner
 from .utils import load_fixture, FakeWikiFile

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -29,22 +29,115 @@ from .utils import load_fixture, FakeWikiFile
 class HTMLCleanerTestCase(unittest.TestCase):
     """Tests for HTMLCleaner."""
 
+    def setUp(self):
+        """Prepare test fixtures."""
+        self.process = HTMLCleaner()
+        self.article_1 = load_fixture('article_with_images.html')
+        self.article_2 = load_fixture('article_with_inlinemath.html')
+
     def test_remove_inlinemath(self):
-        html = load_fixture('article_with_inlinemath.html')
-        assert 'MJX-TeXAtom-ORD' in html
-        pp = HTMLCleaner()
-        wf = FakeWikiFile(html)
-        result = pp(wf)
+        assert 'MJX-TeXAtom-ORD' in self.article_2
+        wikifile = FakeWikiFile(self.article_2)
+        result = self.process(wikifile)
         self.assertEqual(result, (0, []))
-        self.assertNotIn('MJX-TeXAtom-ORD', wf.html)
+        self.assertNotIn('MJX-TeXAtom-ORD', wikifile.html)
 
     def test_remove_img_srcset(self):
-        html = _load_fixture('article_with_images.html')
         text = 'srcset="//upload.wikimedia.org/'
-        assert text in html
-        pp = HTMLCleaner()
-        wf = FakeWikiFile(html)
-        result = pp(wf)
+        assert text in self.article_1
+        wikifile = FakeWikiFile(self.article_1)
+        result = self.process(wikifile)
         self.assertEqual(result, (0, []))
-        self.assertNotIn(text, wf.html)
+        self.assertNotIn(text, wikifile.html)
+
+    def test_remove_not_last_version_text(self):
+        html = ('<div><div id="contentSub">\n<div class="mw-revision warningbox">'
+                'spam spam spam\n</div> </div>foo bar</div>')
+        html_fixed = '<div><div id="contentSub"></div>foo bar</div>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
+
+    def test_remove_edit_section(self):
+        html = ('<h2>Title<span class="mw-editsection">'
+                '<span>[Edit]</span></span></h2>')
+        html_fixed = '<h2>Title<span class="mw-editsection"></span></h2>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
+
+    def test_remove_ambox(self):
+        html = ('<table class="ambox ambox-content">'
+                '<tr><td>Spam Spam</td></tr></table>')
+        html_fixed = '<table class="ambox ambox-content"></table>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
+
+    def test_remove_links_keep_text(self):
+        texts_keep = ('Discusión', 'Categoría')
+        texts_remove = tuple(t[0] for t in HTMLCleaner.unwrap_links)
+        assert all(text in self.article_1 for text in texts_keep)
+        assert all(text in self.article_1 for text in texts_remove)
+        wikifile = FakeWikiFile(self.article_1)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        assert all(text in wikifile.html for text in texts_keep)
+        assert not all(text in wikifile.html for text in texts_remove)
+
+    def test_remove_hidden_subtitle(self):
+        html = '<div><div id="siteSub">Spam Spam</div>foo bar</div>'
+        html_fixed = '<div>foo bar</div>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
+
+    def test_remove_inline_alerts(self):
+        # Make shure references like `[1]` are not touched.
+        html = ('<p>Foo<sup>[<i><a href="link">spam spam<a></i>]</sup> '
+                'bar<sup>[<a href="#cite_note-1">1</a>]</sup></p>')
+        html_fixed = '<p>Foo bar<sup>[<a href="#cite_note-1">1</a>]</sup></p>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
+
+    def test_remove_printfooter(self):
+        text = '<div class="printfooter">'
+        assert text in self.article_1
+        wikifile = FakeWikiFile(self.article_1)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        assert text not in wikifile.html
+
+    def test_remove_hidden_categories(self):
+        html = ('<div id="catlinks"><div id="mw-normal-catlinks">Foo</div>'
+                '<div id="mw-hidden-catlinks">Spam</div></div>')
+        html_fixed = '<div id="catlinks"><div id="mw-normal-catlinks">Foo</div></div>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
+
+    def test_remove_comments(self):
+        html = ('<div>foo<!--spam spam--></div>'
+                '<div>bar</div><!--\nspam\nspam\nspam\n-->')
+        html_fixed = '<div>foo</div><div>bar</div>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
+
+    def test_remove_parsing_errors(self):
+        html = ('<p>Foo<span class="error mw-ext-cite-error" lang="es">'
+               'Spam Spam</span> bar</p>')
+        html_fixed = '<p>Foo bar</p>'
+        wikifile = FakeWikiFile(html)
+        result = self.process(wikifile)
+        self.assertEqual(result, (0, []))
+        self.assertEqual(html_fixed, wikifile.html)
 

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -22,12 +22,7 @@ import unittest
 import os
 
 from src.preprocessing.preprocessors import HTMLCleaner
-from .utils import load_fixture
-
-
-class FakeWikiFile:
-    def __init__(self, html):
-        self.html = html
+from .utils import load_fixture, FakeWikiFile
 
 
 class HTMLCleanerTestCase(unittest.TestCase):

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -77,7 +77,7 @@ class WebAppTestCase(unittest.TestCase):
 
         response = self.client.get("/al_azar", follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("De Wikipedia, la enciclopedia libre" in response.data)
+        self.assertTrue('h1 class="firstHeading"' in response.data)
 
     def test_institucional(self):
         response = self.client.get("/institucional/ayuda.html")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,12 @@
 import os
 
 
+class FakeWikiFile:
+    def __init__(self, html, url='url'):
+        self.html = html
+        self.url = url
+
+
 def load_fixture(filename):
     """Load a fixture from disk."""
     filepath = os.path.join(os.getcwd(), 'tests', 'fixtures', filename)

--- a/utilities/scraper.py
+++ b/utilities/scraper.py
@@ -270,23 +270,15 @@ class WikipediaArticle(object):
 regex = (
     '(<h1 id="firstHeading" class="firstHeading" '
     'lang=".+">.+</h1>)(.+)\s*<div class="printfooter">')
-capturar = re.compile(regex, re.MULTILINE | re.DOTALL).search
-no_ocultas = re.compile('<div id="mw-hidden-catlinks".*?</div>', re.MULTILINE | re.DOTALL)
-no_pp_report = re.compile("<!--\s*?NewPP limit report.*?-->", re.MULTILINE | re.DOTALL)
+capture = re.compile(regex, re.MULTILINE | re.DOTALL).search
 
 
 def extract_content(html, url):
-    encontrado = capturar(html)
-    if not encontrado:
+    found = capture(html)
+    if not found:
         # unknown html format
-        raise ValueError("El archivo %s posee un formato desconocido" % url)
-    newhtml = "\n".join(encontrado.groups())
-
-    # algunas limpiezas más
-    newhtml = no_ocultas.sub("", newhtml)
-    newhtml = no_pp_report.sub("", newhtml)
-
-    return newhtml
+        raise ValueError("HTML file from %s has an unknown format" % url)
+    return "\n".join(encontrado.groups())
 
 
 @defer.inlineCallbacks

--- a/utilities/scraper.py
+++ b/utilities/scraper.py
@@ -278,7 +278,7 @@ def extract_content(html, url):
     if not found:
         # unknown html format
         raise ValueError("HTML file from %s has an unknown format" % url)
-    return "\n".join(encontrado.groups())
+    return "\n".join(found.groups())
 
 
 @defer.inlineCallbacks


### PR DESCRIPTION
Changes summary:

- Move some cleaning tasks away from scraper module,
  use BeautifulSoup instead of regular expressions.
- Remove inline alerts (like `[cita requerida]`, see [example page][1])
- Remove mediawiki parsing error red notice (see example page, at the end)
- Remove hidden content: subtitle, printfooter, hidden categories, HTML comments.
- Add tests for all HTMLCleaner tasks.

[1]: https://es.wikipedia.org/w/index.php?title=El_Universal_(M%C3%A9xico)&oldid=125069288