### PR TITLE
Migration to Python3 fix tests

### DIFF
--- a/src/armado/compresor.py
+++ b/src/armado/compresor.py
@@ -32,10 +32,8 @@ Formato del bloque:
 """
 
 
-
 import bz2
 import os
-import codecs
 import struct
 import pickle as pickle
 from os import path

--- a/src/armado/compressed_index.py
+++ b/src/armado/compressed_index.py
@@ -620,7 +620,8 @@ class Index(object):
             print("\r Computing similitude matrix...  %d%%\t" % int(p), file=sys.stderr)
             sys.stderr.flush()
 
-        matrix = TermSimilitudeMatrix(map(operator.itemgetter(0), sitems), progress_callback=progress_cb)
+        matrix = TermSimilitudeMatrix(map(operator.itemgetter(0), sitems),
+                                      progress_callback=progress_cb)
         docsets = FrozenStringList(map(operator.itemgetter(1), sitems))
         del sitems
 

--- a/src/images/download.py
+++ b/src/images/download.py
@@ -22,7 +22,8 @@ import codecs
 import collections
 import logging
 import os
-import urllib.request, urllib.error
+import urllib.request
+import urllib.error
 
 import config
 

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -276,8 +276,8 @@ class ImageParser(object):
         querystr = '?s=%s-%s' % (img_width, img_height) if img_width and img_height else ''
 
         # Replace the origial src with the local servable path
-        tag.attrs['src'] = IMG_URL_PREFIX + "%s%s" % (urllib.parse.quote(dsk_url.encode("latin-1")),
-                                                      querystr)
+        tag.attrs['src'] = IMG_URL_PREFIX + "%s%s" % (urllib.parse.quote(
+                                                      dsk_url.encode("latin-1")), querystr)
 
         tag.attrs.pop("data-file-height", None)
         tag.attrs.pop("data-file-width", None)

--- a/src/preprocessing/preprocess.py
+++ b/src/preprocessing/preprocess.py
@@ -25,7 +25,6 @@ the priority for it to be included (or not) in the compilation.
 """
 
 
-
 import codecs
 import logging
 import operator

--- a/src/preprocessing/preprocessors.py
+++ b/src/preprocessing/preprocessors.py
@@ -35,7 +35,6 @@ None instead of the score.
 """
 
 
-
 import base64
 import codecs
 import collections

--- a/src/scraping/scraper.py
+++ b/src/scraping/scraper.py
@@ -319,8 +319,8 @@ def reemplazar_links_paginado(html, n):
 
 
 def get_temp_file(temp_dir):
-    return tempfile.NamedTemporaryFile(suffix='.html', prefix='scrap-', dir=temp_dir, delete=False,
-                                       encoding="utf-8")
+    return tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8', suffix='.html',
+                                       prefix='scrap-', dir=temp_dir, delete=False, )
 
 
 def save_htmls(data_url):

--- a/src/scraping/scraper.py
+++ b/src/scraping/scraper.py
@@ -27,10 +27,11 @@ import json
 import logging
 import os
 import re
-import sys
 import tempfile
 import time
-import urllib.request, urllib.error, urllib.parse
+import urllib.error
+import urllib.parse
+import urllib.request
 
 import concurrent.futures
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -49,17 +49,18 @@ def _get_python_filepaths():
     return python_paths
 
 
-def test_flake8(mocker):
+def test_flake8(capsys):
     # verify all files are nicely styled
     python_filepaths = _get_python_filepaths()
     style_guide = get_style_guide(**FLAKE8_OPTIONS)
-    fake_stdout = mocker.patch('sys.stdout')
     report = style_guide.check_files(python_filepaths)
 
     if report.total_errors != 0:
-        issues = fake_stdout.getvalue().split('\n')
+        captured = capsys.readouterr()
+        issues = captured.out.split('\n')
         msg = "Please fix the following flake8 issues!\n" + "\n".join(issues)
-        pytest.fail(msg, pytrace=False)
+        with capsys.disabled():
+            pytest.fail(msg, pytrace=False)
 
 
 def test_ensure_copyright():

--- a/utilities/verComprimido.py
+++ b/utilities/verComprimido.py
@@ -43,7 +43,7 @@ def main(fname, a_extraer):
     archivos = []
     redirects = 0
     for name, info in c.header.items():
-        if isinstance(info, basestring):
+        if isinstance(info, str):
             redirects += 1
         else:
             (seek, size) = info


### PR DESCRIPTION
En py38 el scraper me tiraba `ValueError("binary mode doesn't take an encoding argument")`, lo corregí agregando `mode='w+'` en la creación del tempfile (54491a0).

En el test de flake8 que fallaba cambié el mock de `sys.stdout` por el fixture `capsys` que es builtin (2799ed9), con eso empezó a funcionar, después corregí los warnings (69ad70c)

Con estos cambios, generé una CDPedia en test mode, la probé y todo parecía funcionar bien (el bmp.py genera una imágen negra pero eso se corrige después)