### PR TITLE
Embed SVG images in HTML source

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,8 +41,8 @@ EDICION_ESPECIAL = None
 
 # Ubicación de los archivos estáticos online
 # Debe tener la barra al final
-URL_WIKIPEDIA = u"http://es.wikipedia.org/"
-IDIOMA = "es"
+URL_WIKIPEDIA = "http://es.wikipedia.org/"
+LANGUAGE = "es"
 
 # Directorios especiales con metadata y cosas que no son los HTMLs de las
 # páginas en sí
@@ -109,11 +109,23 @@ PAG_ELEGIDAS = "temp/pag_elegidas.txt"
 # Logs varios:
 LOG_REDIRECTS = DIR_TEMP + "/redirects.txt"
 LOG_PREPROCESADO = DIR_TEMP + "/preprocesado.txt"
+
 LOG_IMAGENES = DIR_TEMP + "/imagenes.txt"
 LOG_IMAGPROC = DIR_TEMP + "/imag_proc.txt"
 LOG_REDUCCION = DIR_TEMP + "/reduccion.txt"
 LOG_REDUCDONE = DIR_TEMP + "/reduc_done.txt"
 LOG_TITLES = DIR_TEMP + "/titles.txt"
+
+# prefix for URL of local images
+IMGAGES_URL_PREFIX = "/images/"
+
+# enable mandatory inclusion of some images in final distribution (e.g. SVG)
+IMAGES_REQUIRED = True
+LOG_IMAGES_REQUIRED = DIR_TEMP + '/images_required.txt'
+
+# enable embedding of some images in HTML source (e.g. small SVG)
+IMAGES_EMBED = True
+LOG_IMAGES_EMBED = DIR_TEMP + '/images_embed.txt'
 
 # Formato general de los logs:
 SEPARADOR_COLUMNAS = '|'

--- a/config.py
+++ b/config.py
@@ -109,7 +109,6 @@ PAG_ELEGIDAS = "temp/pag_elegidas.txt"
 # Logs varios:
 LOG_REDIRECTS = DIR_TEMP + "/redirects.txt"
 LOG_PREPROCESADO = DIR_TEMP + "/preprocesado.txt"
-
 LOG_IMAGENES = DIR_TEMP + "/imagenes.txt"
 LOG_IMAGPROC = DIR_TEMP + "/imag_proc.txt"
 LOG_REDUCCION = DIR_TEMP + "/reduccion.txt"
@@ -117,15 +116,15 @@ LOG_REDUCDONE = DIR_TEMP + "/reduc_done.txt"
 LOG_TITLES = DIR_TEMP + "/titles.txt"
 
 # prefix for URL of local images
-IMGAGES_URL_PREFIX = "/images/"
+IMAGES_URL_PREFIX = "/images/"
 
 # enable mandatory inclusion of some images in final distribution (e.g. SVG)
 IMAGES_REQUIRED = True
 LOG_IMAGES_REQUIRED = DIR_TEMP + '/images_required.txt'
 
 # enable embedding of some images in HTML source (e.g. small SVG)
-IMAGES_EMBED = True
-LOG_IMAGES_EMBED = DIR_TEMP + '/images_embed.txt'
+EMBED_IMAGES = True
+LOG_IMAGES_EMBEDDED = DIR_TEMP + '/images_embed.txt'
 
 # Formato general de los logs:
 SEPARADOR_COLUMNAS = '|'

--- a/src/generate.py
+++ b/src/generate.py
@@ -34,7 +34,7 @@ import config
 from src.preprocessing import preprocess
 from src.armado.compresor import ArticleManager, ImageManager
 from src.armado import cdpindex
-from src.images import extract, download, scale, calculate
+from src.images import extract, download, scale, calculate, embed
 
 
 # para poder hacer generar.py > log.txt
@@ -344,6 +344,10 @@ def main(lang, src_info, branch_dir, version, lang_config, gendate,
 
     logger.info("Reducing the downloaded images")
     scale.run(verbose)
+
+    if config.IMAGES_EMBED:
+        logger.info("Embedding selected images")
+        embed.run()
 
     logger.info("Putting the reduced images into blocks")
     # agrupamos las imagenes en bloques

--- a/src/generate.py
+++ b/src/generate.py
@@ -345,7 +345,7 @@ def main(lang, src_info, branch_dir, version, lang_config, gendate,
     logger.info("Reducing the downloaded images")
     scale.run(verbose)
 
-    if config.IMAGES_EMBED:
+    if config.EMBED_IMAGES:
         logger.info("Embedding selected images")
         embed.run()
 

--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -124,8 +124,9 @@ def run():
     images_optional = sorted(images_optional.items(), key=operator.itemgetter(1))
 
     scaler = Scaler(len(images_optional))
-    for i, (dskurl, _) in enumerate(images_optional):
-        scale = scaler(i)
+    selected_opt = 0  # number of selected optional images
+    for dskurl, _ in images_optional:
+        scale = scaler(selected_opt)
         if scale == 0:
             # done, do not include more images
             break
@@ -133,6 +134,8 @@ def run():
         weburl = dskweb[dskurl]
         info = (str(int(scale)), dskurl, weburl)
         log_reduction.write(separator.join(info) + "\n")
+        selected_opt += 1
 
     log_reduction.close()
-    logger.info("Images selected: required=%d optional=%d", len(images_required), i)
+    selected_req = len(images_required)
+    logger.info("Images selected: required=%d optional=%d", selected_req, selected_opt)

--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf8 -*-
 
-# Copyright 2008-2015 CDPedistas (see AUTHORS.txt)
+# Copyright 2008-2020 CDPedistas (see AUTHORS.txt)
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -18,7 +18,6 @@
 
 """Calculate image scaling values."""
 
-import codecs
 import logging
 import operator
 
@@ -61,9 +60,10 @@ def run():
     # load relation: articles -> images
     page_images = {}
     dynamics = []
-    with codecs.open(config.LOG_IMAGPROC, "r", encoding="utf-8") as fh:
+    separator = config.SEPARADOR_COLUMNAS
+    with open(config.LOG_IMAGPROC, "rt", encoding="utf-8") as fh:
         for line in fh:
-            parts = line.strip().split(config.SEPARADOR_COLUMNAS)
+            parts = line.strip().split(separator)
             dir3 = parts[0]
             fname = parts[1]
             dskurls = parts[2:]
@@ -94,9 +94,9 @@ def run():
 
     # load image list to map disk paths to web addresses
     dskweb = {}
-    with codecs.open(config.LOG_IMAGENES, "r", encoding="utf-8") as fh:
-        for linea in fh:
-            dsk, web = linea.strip().split(config.SEPARADOR_COLUMNAS)
+    with open(config.LOG_IMAGENES, "rt", encoding="utf-8") as fh:
+        for line in fh:
+            dsk, web = line.strip().split(separator)
             dskweb[dsk] = web
 
     logger.info("Calculating scales for %d images", total_images)
@@ -111,4 +111,4 @@ def run():
 
         weburl = dskweb[dskurl]
         info = (str(int(scale)), dskurl, weburl)
-        log_reduccion.write(config.SEPARADOR_COLUMNAS.join(info) + "\n")
+        log_reduction.write(separator.join(info) + "\n")

--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -129,12 +129,11 @@ def run():
         scale = scaler(i)
         if scale == 0:
             # done, do not include more images
-            log_reduction.close()
             break
 
         weburl = dskweb[dskurl]
         info = (str(int(scale)), dskurl, weburl)
         log_reduction.write(separator.join(info) + "\n")
 
-    logger.info("Required images selected: %d", len(images_required))
-    logger.info("Optional images selected: %d", i)
+    log_reduction.close()
+    logger.info("Images selected: required=%d optional=%d", len(images_required), i)

--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -91,7 +91,6 @@ def run():
     preprocessed = preprocess.pages_selector.top_pages
     for file_position, (dir3, fname, _) in enumerate(preprocessed):
         # get the images that correspond to this file
-
         dskurls = page_images[(dir3, fname)]
 
         for url in dskurls:

--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -21,6 +21,7 @@
 
 import logging
 import operator
+import os
 
 import config
 from src.preprocessing import preprocess
@@ -59,7 +60,8 @@ class Scaler:
 def image_is_required(url):
     """Decide if an image should be mandatorily included."""
     # always include svg images (mostly equations, highly compressible)
-    return url.endswith('.svg')
+    _, ext = os.path.splitext(url)
+    return ext.lower() == '.svg'
 
 
 def run():

--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -42,6 +42,8 @@ class Scaler:
         reduction = config.imageconf['image_reduction']
         logger.info("Reduction: %s", reduction)
         for (percentage, scale) in zip(reduction, SCALES):
+            if percentage == 0:
+                continue
             quantity = total_items * percentage / 100
             vals.append((quantity + base, scale))
             base += quantity

--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -31,7 +31,7 @@ logger = logging.getLogger("images.calculate")
 SCALES = (100, 75, 50, 0)
 
 
-class Scaler(object):
+class Scaler:
     """Compute values for image scaling."""
 
     def __init__(self, total_items):

--- a/src/images/download.py
+++ b/src/images/download.py
@@ -18,7 +18,7 @@
 
 """Download images."""
 
-import codecs
+
 import collections
 import logging
 import os
@@ -80,12 +80,12 @@ def retrieve():
     # load images that couldn't be downloaded previously
     log_errors = os.path.join(config.DIR_TEMP, "images_neterror.txt")
     if os.path.exists(log_errors):
-        with codecs.open(log_errors, "r", encoding="utf8") as fh:
+        with open(log_errors, "rt", encoding="utf8") as fh:
             imgs_problems = set(x.strip() for x in fh)
     else:
         imgs_problems = set()
 
-    for line in codecs.open(config.LOG_REDUCCION, "r", encoding="utf8"):
+    for line in open(config.LOG_REDUCCION, "rt", encoding="utf8"):
         line = line.strip()
         if not line:
             continue
@@ -109,7 +109,7 @@ def retrieve():
         else:
             errors[stt] += 1
             n_err += 1
-            with codecs.open(log_errors, "a", encoding="utf8") as fh:
+            with open(log_errors, "at", encoding="utf8") as fh:
                 fh.write(url + "\n")
 
         tl.log("Downloaded image %d/%d (ok=%d, err=%d)", i, tot, n_ok, n_err)

--- a/src/images/download.py
+++ b/src/images/download.py
@@ -18,7 +18,6 @@
 
 """Download images."""
 
-
 import collections
 import logging
 import os

--- a/src/images/embed.py
+++ b/src/images/embed.py
@@ -37,7 +37,7 @@ def image_is_embeddable(imgpath, imgsize):
     return ext == 'svg' and imgsize < 40960
 
 
-class EmbedImages(object):
+class EmbedImages:
     """Embed images in HTML file."""
 
     media_type = {

--- a/src/images/embed.py
+++ b/src/images/embed.py
@@ -104,20 +104,20 @@ class EmbedImages:
 
 def load_embed_data():
     """Load `page -> images_to_embed` relation."""
-    # load embeddable image paths
-    with open(config.LOG_IMAGES_EMBED, 'rt', encoding='utf-8') as fh:
-        embeddable_images = set(line.strip() for line in fh)
+    # load to-be-embedded image paths
+    with open(config.LOG_IMAGES_EMBEDDED, 'rt', encoding='utf-8') as fh:
+        images_to_embed = set(line.strip() for line in fh)
 
     # find what images must be embedded in each page
     page_embeds = {}
-    prefix = config.IMGAGES_URL_PREFIX
+    prefix = config.IMAGES_URL_PREFIX
     separator = config.SEPARADOR_COLUMNAS
     with open(config.LOG_IMAGPROC, "rt", encoding="utf-8") as fh:
         for line in fh:
             dir3, fname, *page_images = line.strip().split(separator)
             if dir3 == config.DYNAMIC:
                 continue
-            embeds = embeddable_images & set(page_images)
+            embeds = images_to_embed & set(page_images)
             if embeds:
                 page_embeds[(dir3, fname)] = set(prefix + e for e in embeds)
     return page_embeds

--- a/src/images/embed.py
+++ b/src/images/embed.py
@@ -25,7 +25,6 @@ import bs4
 
 import config
 
-
 logger = logging.getLogger('images.embed')
 
 

--- a/src/images/embed.py
+++ b/src/images/embed.py
@@ -1,0 +1,133 @@
+# Copyright 2020 CDPedistas (see AUTHORS.txt)
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  https://github.com/PyAr/CDPedia/
+
+"""Embed pre-selected images in HTML source."""
+
+import logging
+import os
+from base64 import standard_b64encode
+
+import bs4
+
+import config
+
+
+logger = logging.getLogger('images.embed')
+
+
+def image_is_embeddable(imgpath, imgsize):
+    """Decide if given image will be embedded in HTML source."""
+    try:
+        ext = os.path.splitext(imgpath)[1].lstrip('.').lower()
+    except IndexError:
+        return False
+    return ext == 'svg' and imgsize < 40960
+
+
+class EmbedImages(object):
+    """Embed images in HTML file."""
+
+    media_type = {
+        'png': 'image/png',
+        'gif': 'image/gif',
+        'jpg': 'image/jpeg',
+        'jpeg': 'image/jpeg',
+        'svg': 'image/svg+xml'
+    }
+
+    def __call__(self, htmlpath, images):
+        return self.embed_images(htmlpath, images)
+
+    def embed_images(self, htmlpath, images):
+        """Embed specified images in HTML source."""
+
+        # load html soup
+        with open(htmlpath, 'rb') as fh:
+            soup = bs4.BeautifulSoup(fh, features='lxml', from_encoding='utf-8')
+
+        # search img tags to embed images
+        for node in soup.find_all('img', src=True):
+            src = node.attrs['src'].rsplit('?', 1)[0]
+            if src not in images:
+                continue
+
+            # take embeddable images from original download location
+            imgpath = config.DIR_TEMP + src  # src starts with `/`
+            kind = os.path.splitext(src)[1].lstrip('.').lower()
+            if kind == 'svg':
+                self.embed_inline(node, imgpath)
+            elif kind in ('png', 'gif', 'jpg', 'jpeg'):
+                self.embed_data(node, imgpath, kind)
+            else:
+                logger.error('Embed method not found for: %s', imgpath)
+
+        # dump updated html
+        html = soup.encode(encoding='utf-8')
+        with open(htmlpath, 'wb') as fh:
+            fh.write(html)
+
+    def load_vector(self, imgpath):
+        """Read SVG from disk and return a Tag object."""
+        with open(imgpath, 'rb') as fh:
+            xml = bs4.BeautifulSoup(fh, features='xml', from_encoding='utf-8')
+        return xml.find('svg')
+
+    def load_data(self, imgpath):
+        """Read image content from disk, return it base64-encoded."""
+        with open(imgpath, 'rb') as fh:
+            return standard_b64encode(fh.read()).decode('ascii')
+
+    def embed_inline(self, node, imgpath):
+        """Embed SVG image directly in HTML tree"""
+        svg = self.load_vector(imgpath)
+        node.replace_with(svg)
+
+    def embed_data(self, node, imgpath, kind):
+        """Embed raster/vector image using data URI scheme."""
+        imgdata = self.load_data(imgpath)
+        media_type = self.media_type[kind]
+        node['src'] = 'data:{};base64,{}'.format(media_type, imgdata)
+
+
+def load_embed_data():
+    """Load `page -> images_to_embed` relation."""
+    # load embeddable image paths
+    with open(config.LOG_IMAGES_EMBED, 'rt', encoding='utf-8') as fh:
+        embeddable_images = set(line.strip() for line in fh)
+
+    # find what images must be embedded in each page
+    page_embeds = {}
+    prefix = config.IMGAGES_URL_PREFIX
+    separator = config.SEPARADOR_COLUMNAS
+    with open(config.LOG_IMAGPROC, "rt", encoding="utf-8") as fh:
+        for line in fh:
+            dir3, fname, *page_images = line.strip().split(separator)
+            if dir3 == config.DYNAMIC:
+                continue
+            embeds = embeddable_images & set(page_images)
+            if embeds:
+                page_embeds[(dir3, fname)] = set(prefix + e for e in embeds)
+    return page_embeds
+
+
+def run():
+    """Embed pre-selected images into HTML sources."""
+    embed = EmbedImages()
+    page_embeds = load_embed_data()
+    for (dir3, fname), images in page_embeds.items():
+        htmlpath = os.path.join(config.DIR_PAGSLISTAS, dir3, fname)
+        logger.debug('Embedding %3d images in %s', len(images), fname)
+        embed(htmlpath, images)

--- a/src/images/embed.py
+++ b/src/images/embed.py
@@ -30,11 +30,8 @@ logger = logging.getLogger('images.embed')
 
 def image_is_embeddable(imgpath, imgsize):
     """Decide if given image will be embedded in HTML source."""
-    try:
-        ext = os.path.splitext(imgpath)[1].lstrip('.').lower()
-    except IndexError:
-        return False
-    return ext == 'svg' and imgsize < 40960
+    _, ext = os.path.splitext(imgpath)
+    return ext.lower() == '.svg' and imgsize < 40960
 
 
 class EmbedImages:

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -24,7 +24,7 @@ those URLs for them to point to disk.
 Also log the URLs that needs to be downloaded.
 """
 
-import codecs
+
 import logging
 import os
 import sys
@@ -70,7 +70,7 @@ class ImageParser(object):
         same_before = preprocess.pages_selector.same_info_through_runs
         self.processed_before = {}
         if not test and same_before and os.path.exists(config.LOG_IMAGPROC):
-            with codecs.open(config.LOG_IMAGPROC, "r", encoding="utf-8") as fh:
+            with open(config.LOG_IMAGPROC, "rt", encoding="utf-8") as fh:
                 for line in fh:
                     parts = line.strip().split(config.SEPARADOR_COLUMNAS)
                     dir3 = parts[0]
@@ -83,7 +83,7 @@ class ImageParser(object):
         # load information of planned downloads
         self.downloads_planned = {}
         if not test and os.path.exists(config.LOG_IMAGENES):
-            with codecs.open(config.LOG_IMAGENES, "r", encoding="utf-8") as fh:
+            with open(config.LOG_IMAGENES, "rt", encoding="utf-8") as fh:
                 for line in fh:
                     dsk, web = line.strip().split(config.SEPARADOR_COLUMNAS)
                     self.downloads_planned[dsk] = web
@@ -96,14 +96,14 @@ class ImageParser(object):
         sep = config.SEPARADOR_COLUMNAS
         self.chosen_pages = set()
         if not test:
-            with codecs.open(config.PAG_ELEGIDAS, "r", encoding="utf-8") as fh:
+            with open(config.PAG_ELEGIDAS, "rt", encoding="utf-8") as fh:
                 self.chosen_pages = set(x.strip().split(sep)[1] for x in fh)
         logger.debug("Quantity of chosen pages, raw: %d",
                      len(self.chosen_pages))
 
         chpages = self.chosen_pages
         if not test:
-            with codecs.open(config.LOG_REDIRECTS, "r", encoding="utf-8") as fh:
+            with open(config.LOG_REDIRECTS, "rt", encoding="utf-8") as fh:
                 for line in fh:
                     orig, dest = line.strip().split(sep)
                     if dest in chpages:
@@ -118,12 +118,12 @@ class ImageParser(object):
         """Log processed images."""
         separator = config.SEPARADOR_COLUMNAS
         # write the images log
-        with codecs.open(config.LOG_IMAGENES, "w", encoding="utf-8") as fh:
+        with open(config.LOG_IMAGENES, "wt", encoding="utf-8") as fh:
             for k, v in self.to_download.items():
                 fh.write("%s%s%s\n" % (k, separator, v))
 
         # rewrite list of walked preprocessed files
-        with codecs.open(config.LOG_IMAGPROC, "w", encoding="utf-8") as fh:
+        with open(config.LOG_IMAGPROC, "wt", encoding="utf-8") as fh:
             for (dir3, fname), dskurls in self.process_now.items():
                 if dskurls:
                     dskurls = separator.join(dskurls)
@@ -167,7 +167,7 @@ class ImageParser(object):
 
         # read the html from the previous processing step
         arch = os.path.join(config.DIR_PREPROCESADO, dir3, fname)
-        with codecs.open(arch, "r", encoding="utf-8") as fh:
+        with open(arch, "rt", encoding="utf-8") as fh:
             html = fh.read()
 
         html, newimgs = self.parse_html(html, self.chosen_pages)
@@ -179,7 +179,7 @@ class ImageParser(object):
                 os.makedirs(destdir)
 
             newpath = os.path.join(destdir, fname)
-            with codecs.open(newpath, "w", encoding="utf-8") as fh:
+            with open(newpath, "wt", encoding="utf-8") as fh:
                 fh.write(html)
 
         # update the images to download

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -37,7 +37,7 @@ from src import utiles
 from src.preprocessing import preprocess
 
 
-IMG_URL_PREFIX = config.IMGAGES_URL_PREFIX
+IMG_URL_PREFIX = config.IMAGES_URL_PREFIX
 
 WIKIPEDIA_URL = "https://{}.wikipedia.org".format(config.LANGUAGE)
 

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -37,9 +37,9 @@ from src import utiles
 from src.preprocessing import preprocess
 
 
-IMG_URL_PREFIX = "/images/"
+IMG_URL_PREFIX = config.IMGAGES_URL_PREFIX
 
-WIKIPEDIA_URL = "https://es.wikipedia.org"
+WIKIPEDIA_URL = "https://{}.wikipedia.org".format(config.LANGUAGE)
 
 # we plainly don't want some images
 IMAGES_TO_REMOVE = [

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -52,7 +52,7 @@ SEPLINK = "/wiki/"
 logger = logging.getLogger('images.extract')
 
 
-class ImageParser(object):
+class ImageParser:
     """Extract from HTMLs, fix, and log, the URLs of the images.
 
     The logged URLs are unique (there are a *lot* of duplicated URLs).

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -28,7 +28,6 @@ import subprocess
 
 from src.images.embed import image_is_embeddable
 
-
 logger = logging.getLogger('images.scale')
 
 

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -20,7 +20,6 @@
 
 from __future__ import with_statement, unicode_literals
 
-import codecs
 import config
 import logging
 import os
@@ -39,7 +38,7 @@ def run(verbose):
     # load already processed images
     done_before = {}
     if os.path.exists(config.LOG_REDUCDONE):
-        with codecs.open(config.LOG_REDUCDONE, "r", encoding="utf-8") as fh:
+        with open(config.LOG_REDUCDONE, "rt", encoding="utf-8") as fh:
             for line in fh:
                 parts = line.strip().split()
                 scale = int(parts[0])
@@ -50,7 +49,7 @@ def run(verbose):
     dst = os.path.join(config.DIR_IMGSLISTAS)
 
     # load image path and its correspondig scale
-    with codecs.open(config.LOG_REDUCCION, "r", encoding="utf-8") as fh:
+    with open(config.LOG_REDUCCION, "rt", encoding="utf-8") as fh:
         for line in fh:
             parts = line.strip().split(config.SEPARADOR_COLUMNAS)
             scale = int(parts[0])
@@ -94,7 +93,7 @@ def run(verbose):
                     logger.warning("Got %d when processing %s", errorcode, frompath)
 
     # save images processed now
-    with codecs.open(config.LOG_REDUCDONE, "w", encoding="utf-8") as fh:
+    with open(config.LOG_REDUCDONE, "wt", encoding="utf-8") as fh:
         for dskurl, scale in done_now.items():
             fh.write("%3d %s\n" % (scale, dskurl))
 

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -36,7 +36,7 @@ def run(verbose):
     """Reduce images using precalculated scales."""
     notfound = 0
     done_now = {}
-    embed_enabled = config.IMAGES_EMBED
+    embed_enabled = config.EMBED_IMAGES
 
     # load already processed images
     done_before = {}
@@ -50,8 +50,8 @@ def run(verbose):
 
     # load paths of embeddable images selected previously
     images_embed = set()
-    if embed_enabled and os.path.exists(config.LOG_IMAGES_EMBED):
-        with open(config.LOG_IMAGES_EMBED, 'rt', encoding='utf-8') as fh:
+    if embed_enabled and os.path.exists(config.LOG_IMAGES_EMBEDDED):
+        with open(config.LOG_IMAGES_EMBEDDED, 'rt', encoding='utf-8') as fh:
             images_embed = set(line.strip() for line in fh)
 
     src = os.path.join(config.DIR_TEMP, "images")
@@ -113,7 +113,7 @@ def run(verbose):
             fh.write("%3d %s\n" % (scale, dskurl))
 
     # save paths of selected images to be embedded
-    with open(config.LOG_IMAGES_EMBED, 'wt', encoding='utf-8') as fh:
+    with open(config.LOG_IMAGES_EMBEDDED, 'wt', encoding='utf-8') as fh:
         for dskurl in images_embed:
             fh.write(dskurl + '\n')
 

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -96,8 +96,8 @@ def run(verbose):
                     # don't copy image, leave it out of image blocks, it will
                     # be embedded from original location (without any reduction)
                     images_embed.add(dskurl)
-                    continue
-                shutil.copyfile(frompath, topath)
+                else:
+                    shutil.copyfile(frompath, topath)
 
             else:
                 cmd = ['convert', frompath, '-resize', '%d%%' % (scale,), topath]

--- a/tests/test_images_calculate.py
+++ b/tests/test_images_calculate.py
@@ -1,0 +1,146 @@
+# Copyright 2020 CDPedistas (see AUTHORS.txt)
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  https://github.com/PyAr/CDPedia/
+
+import os
+
+import config
+from src.images import calculate
+
+import pytest
+
+
+@pytest.fixture
+def image_config(mocker, tmp_path):
+    """Dummy configuration for image processing."""
+    mocker.patch('config.LOG_IMAGPROC', str(tmp_path / 'proc.txt'))
+    mocker.patch('config.LOG_IMAGENES', str(tmp_path / 'imag.txt'))
+    mocker.patch('config.LOG_REDUCCION', str(tmp_path / 'red.txt'))
+    mocker.patch('config.LOG_IMAGES_EMBEDDED', str(tmp_path / 'emb.txt'))
+    imgr = {'image_reduction': [5, 5, 10, 80]}
+    mocker.patch('config.imageconf', imgr, create=True)
+
+
+@pytest.fixture
+def image_data(mocker, image_config):
+    """Dummy data expected for image processing."""
+
+    # images in articles: dir3|article_title|img1|img2...
+    with open(config.LOG_IMAGPROC, 'wt', encoding='utf-8') as fh:
+        fh.write('e/g/g|eggs|foo.png|bar.bmp\n')
+        fh.write('b/a/c|bacon|foo.png\n')
+        fh.write('h/a/m|ham|baz.svg\n')
+        fh.write('s/p/a|spam|spam.svg\n')
+        fh.write('__dynamic__|portals|bar.bmp\n')  # special
+
+    # diskname and external URL of images: name|url
+    with open(config.LOG_IMAGENES, 'wt', encoding='utf-8') as fh:
+        fh.write('foo.png|url_foo\n')
+        fh.write('bar.bmp|url_bar\n')
+        fh.write('baz.svg|url_baz\n')
+        fh.write('spam.svg|url_spam\n')
+
+    # Mock top pages selection: (dir3, fname, score)
+    tops = [
+        ('e/g/g', 'eggs', 80),
+        ('b/a/c', 'bacon', 60),
+        ('h/a/m', 'ham', 40),
+        ('s/p/a', 'spam', 20)
+    ]
+    mocker.patch('src.images.calculate.preprocess.pages_selector',
+                 mocker.Mock(top_pages=tops))
+
+
+def test_scaler(image_config):
+    """Test correct reduction values for a given number of images."""
+    images = 100  # keep it simple
+    s = calculate.SCALES
+    p = config.imageconf['image_reduction']
+    expect = [x for i in range(len(s)) for x in [s[i]]*p[i]] 
+    scaler = calculate.Scaler(images)
+    result = [scaler(i) for i in range(images)]
+    assert expect == result
+
+
+@pytest.mark.parametrize('image_url, expected_result', (
+    ('foo/bar.svg', True),
+    ('foo/bar..SVg', True),
+    ('foo/bar.png', False),
+    ('foo/bar.svg.png', False),
+    ('spam.gif', False),
+    ('foo/svg', False),
+))
+def test_is_not_required(image_url, expected_result):
+    """Test images that should/shouldn't be recognized as required."""
+    assert expected_result == calculate.image_is_required(image_url)
+
+
+@pytest.mark.parametrize('reduction', (
+    (0, 0, 0, 100),
+    (10, 20, 30, 50),
+    (20, 30, 50, 0),
+    (100, 0, 0, 0),
+))
+def test_required_images(reduction, mocker, image_data):
+    """Test that required images are included independently of reduction values."""
+    mocker.patch('config.IMAGES_REQUIRED', True)
+    mocker.patch('config.imageconf', {'image_reduction': reduction})
+    calculate.run()
+    with open(config.LOG_REDUCCION, 'r', encoding='utf-8') as fh:
+        images = fh.read()
+    assert 'baz.svg' in images
+    assert 'spam.svg' in images
+
+
+def test_required_images_only(mocker, image_data):
+    """Test inclusion of required images only."""
+    mocker.patch('config.IMAGES_REQUIRED', True)
+    reduction = [0, 0, 0, 100]  # no optional images
+    mocker.patch('config.imageconf', {'image_reduction': reduction})
+    calculate.run()
+    with open(config.LOG_REDUCCION, 'r', encoding='utf-8') as fh:
+        images = fh.read()
+    assert 'baz.svg' in images
+    assert 'spam.svg' in images
+    # only the two required SVG images should be included
+    assert len(images.split()) == 2
+
+
+def test_no_images(mocker, image_data):
+    """Test no images included."""
+    mocker.patch('config.IMAGES_REQUIRED', False)
+    mocker.patch('config.imageconf', {'image_reduction': [0, 0, 0, 100]})
+    calculate.run()
+    assert os.path.getsize(config.LOG_REDUCCION) == 0
+
+
+def test_no_repeated_images(mocker, image_data):
+    """Image with same name should be included only once."""
+    mocker.patch('config.IMAGES_REQUIRED', True)
+    mocker.patch('config.imageconf', {'image_reduction': [30, 30, 40, 0]})
+    calculate.run()
+    with open(config.LOG_REDUCCION, 'rt', encoding='utf-8') as fh:
+        images = fh.read()
+    assert images.count('foo.png') == 1
+
+
+def test_dynamic_images_priority(mocker, image_data):
+    """Dynamic images should be first in images list."""
+    mocker.patch('config.IMAGES_REQUIRED', False)
+    mocker.patch('config.imageconf', {'image_reduction': [30, 30, 40, 0]})
+    calculate.run()
+    with open(config.LOG_REDUCCION, 'rt', encoding='utf-8') as fh:
+        first_image_info = fh.read().split()[0]
+    assert 'bar.bmp' in first_image_info

--- a/tests/test_images_embed.py
+++ b/tests/test_images_embed.py
@@ -1,0 +1,126 @@
+# Copyright 2020 CDPedistas (see AUTHORS.txt)
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  https://github.com/PyAr/CDPedia/
+
+import bs4
+
+import config
+from src.images import embed
+
+import pytest
+
+
+@pytest.fixture
+def svg_image(tmp_path):
+    """Dummy SVG image."""
+    svg = '<?xml version="1.0" encoding="UTF-8"?>\n<svg><rect/></svg>'
+    filedir = tmp_path / config.IMAGES_URL_PREFIX.lstrip(r'/')
+    filedir.mkdir(parents=True)
+    filepath = filedir / 'foo.svg'
+    with filepath.open('wt', encoding='utf-8') as fh:
+        fh.write(svg)
+    return filepath
+
+
+@pytest.fixture
+def html_file(tmp_path):
+    """Dummy HTML file with images."""
+    html = '<html><body><img src="/images/foo.svg?s=10-10"></body></html>'
+    # x = tmp_path.mkdir('f/o/o', parents=True)
+    filedir = tmp_path / 'f/o/o'
+    filedir.mkdir(parents=True)
+    filepath = filedir / 'foo'  # no extension
+    with filepath.open('wt', encoding='utf-8') as fh:
+        fh.write(html)
+    return filepath
+
+
+@pytest.fixture
+def images_data(mocker, tmp_path):
+    """Dummy image data files."""
+    mocker.patch('config.DIR_TEMP', str(tmp_path))
+    mocker.patch('config.DIR_PAGSLISTAS', str(tmp_path))
+
+    # page images
+    mocker.patch('config.LOG_IMAGPROC', str(tmp_path / 'img.txt'))
+    sep = config.SEPARADOR_COLUMNAS
+    with open(config.LOG_IMAGPROC, 'wt', encoding='utf-8') as fh:
+        fh.write(sep.join(('f/o/o', 'foo', 'foo.png', 'foo.svg')))
+
+    # images to be embedded
+    mocker.patch('config.LOG_IMAGES_EMBEDDED', str(tmp_path / 'emb.txt'))
+    with open(config.LOG_IMAGES_EMBEDDED, 'wt', encoding='utf-8') as fh:
+        fh.write('foo.svg')
+
+
+@pytest.mark.parametrize('imgpath, imgsize, expected_result', (
+    ('foo/bar.svg', 20480, True),
+    ('foo/bar.SvG', 30720, True),
+    ('foo/bar.svg', 51200, False),
+    ('foo/bar.png', 20480, False),
+    ('foo/bar.gif', 20480, False),
+    ('foo/bar.svg.png', 20480, False),
+))
+def test_is_embeddable(imgpath, imgsize, expected_result):
+    """Test that embeddable images are recognized correctly."""
+    assert expected_result == embed.image_is_embeddable(imgpath, imgsize)
+
+
+def test_load_embed_data(images_data):
+    """Test images to embed data loading."""
+    data = embed._load_embed_data()
+    expected_key = 'f/o/o', 'foo'
+    expected_val = {'/images/foo.svg'}
+    assert data.get(expected_key) == expected_val
+
+
+def test_load_vector(svg_image):
+    """Test correct loading of SVG images."""
+    embedder = embed._EmbedImages()
+    node = embedder.load_vector(svg_image)
+    assert getattr(node, 'name', None) == 'svg'
+
+
+def test_embed_vector(svg_image):
+    """Test embedding of SVG image."""
+    embedder = embed._EmbedImages()
+    soup = bs4.BeautifulSoup('<img src="foo.svg">', features='lxml')
+    assert soup.svg is None
+    embedder.embed_vector(soup.img, svg_image)
+    assert soup.svg is not None
+
+
+def test_embed_images(html_file, mocker):
+    """Test general method for embedding images."""
+    mocker.patch('src.images.embed._EmbedImages.embed_vector', mocker.Mock())
+    embedder = embed._EmbedImages()
+    image = '/images/foo.svg'
+    embedder.embed_images(html_file, {image})
+    embedder.embed_vector.assert_called_once()
+    args = embedder.embed_vector.call_args[0]
+    assert len(args) == 2
+    assert args[1] == config.DIR_TEMP + image
+
+
+def test_run(svg_image, html_file, images_data):
+    with open(html_file, 'rb') as fh:
+        html = bs4.BeautifulSoup(fh, features='lxml', from_encoding='utf-8')
+    assert html.find('img') is not None
+    assert html.find('svg') is None
+    embed.run()
+    with open(html_file, 'rb') as fh:
+        html = bs4.BeautifulSoup(fh, features='lxml', from_encoding='utf-8')
+    assert html.find('img') is None
+    assert html.find('svg') is not None

--- a/tests/test_images_embed.py
+++ b/tests/test_images_embed.py
@@ -108,7 +108,6 @@ def test_embed_images(html_file, mocker):
     embedder = embed._EmbedImages()
     image = '/images/foo.svg'
     embedder.embed_images(html_file, {image})
-    embedder.embed_vector.assert_called()
     args = embedder.embed_vector.call_args[0]
     assert len(args) == 2
     assert args[1] == config.DIR_TEMP + image

--- a/tests/test_images_embed.py
+++ b/tests/test_images_embed.py
@@ -31,7 +31,7 @@ def svg_image(tmp_path):
     filepath = filedir / 'foo.svg'
     with filepath.open('wt', encoding='utf-8') as fh:
         fh.write(svg)
-    return filepath
+    return str(filepath)
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ def html_file(tmp_path):
     filepath = filedir / 'foo'  # no extension
     with filepath.open('wt', encoding='utf-8') as fh:
         fh.write(html)
-    return filepath
+    return str(filepath)
 
 
 @pytest.fixture

--- a/tests/test_images_embed.py
+++ b/tests/test_images_embed.py
@@ -108,7 +108,7 @@ def test_embed_images(html_file, mocker):
     embedder = embed._EmbedImages()
     image = '/images/foo.svg'
     embedder.embed_images(html_file, {image})
-    embedder.embed_vector.assert_called_once()
+    embedder.embed_vector.assert_called()
     args = embedder.embed_vector.call_args[0]
     assert len(args) == 2
     assert args[1] == config.DIR_TEMP + image


### PR DESCRIPTION
Agregué 2 parámetros a `config.py`:

#### `IMAGES_REQUIRED = True`

Habilita la inclusión obligatoria de algunas imágenes, según determine la función `image_is_required(imgpath)` que agregué a `images/calculate.py` (por ahora todos los SVG). Estas imágenes se incorporan sin reducción a los bloques (o se incrustan si corresponde).

#### `IMAGES_EMBED = True`

Habilita la incrustación de imágenes en el HTML, según lo determinado por `image_is_embeddable(imgpath, imgsize)` de `images/embed.py` (por ahora sólo SVGs *inline* de menos de 50KB). Las imágenes incrustadas no se incluyen en los bloques y tampoco se escalan (se puede cambiar).

#### Notas/Comentarios

- El tiempo de carga de páginas con muchas fórmulas mejora significativamente. 
- Los navegadores no cachean las imágenes incrustadas. Para los SVG que manejamos no es problema: se usan más que nada para fórmulas y casi nunca se repiten.
- No es conveniente incrustar rasters que se usen en varias páginas por que no se cachean y hay que hacerlo en base64 (ocupan más espacio).
- Hay un error de logging en `compressor.py` que corrige Nico en 856d61a
- Close #258

Escucho sugerencias de cambios o mejoras! Adjunto archivo con artículos que contienen fórmulas para probar: [extra_math.txt](https://github.com/PyAr/CDPedia/files/4860688/extra_math.txt)
