### PR TITLE
Update method for generating cdpedia.exe using pyinstaller

### DIFF
--- a/resources/autorun.win/HOWTO.txt
+++ b/resources/autorun.win/HOWTO.txt
@@ -1,0 +1,32 @@
+Generate cdpedia.exe for Windows autorun
+========================================
+
+The first step must be completed on Linux, the rest on Windows.
+
+- Build a CDPedia image in test mode.
+
+- Copy and extract the image to a Windows directory, e.g. `path\to\cdpedia_image\`.
+
+- Install latest stable python 3.7 (32 bit).
+  pyinstaller doesn't support python 3.8
+  see https://github.com/pyinstaller/pyinstaller/issues/4311
+  
+- Clone or get a copy of the CDPedia project.
+
+- Create a virtualenv specifying python 3.7 (32 bit) as target interpreter:
+  `virtualenv --python=path\to\python37_x86\python.exe venv_exe`
+
+- Activate virtualenv and install dependencies: `pywin32` and `pyinstaller`
+
+- From project dir, run `python utilities\make_autorun.py path\to\cdpedia_image`
+  This creates a new cdpedia.exe in image dir that is also copied to project dir
+
+- Run updated cdpedia.exe from image dir to test it
+
+- If it's OK, commit the updated cdpedia.exe to the project and push.
+
+- Done, the CDPedia test image is no longer needed.
+
+
+Note: tested and working OK using python 3.7.8 32-bit virtualenv with
+pytinstaller 4.0 in a Win10-x64 host.

--- a/utilities/make_autorun.py
+++ b/utilities/make_autorun.py
@@ -1,0 +1,91 @@
+# Copyright 2020 CDPedistas (see AUTHORS.txt)
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  https://github.com/PyAr/CDPedia/
+
+"""
+Usage: python make_autorun.py <cdpedia_image_dir> [temp_dir]
+
+See instructions and setup requirements in resources/autorun.win/HOWTO.txt
+
+"""
+
+import logging
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+
+logger = logging.getLogger('make_autorun')
+
+if os.name != 'nt':
+    logger.error('This script is meant to be run on Windows.')
+    sys.exit()
+
+if struct.calcsize("P") != 4:
+    # void pointer size of a 32 bit python interpreter is 4 bytes
+    logger.error('This script is meant to be run on 32 bit python')
+    sys.exit()
+
+
+def build_exe(imagedir, tempdir=None):
+    """Create a single executable for running CDPedia on Windows."""
+
+    logger.info('Generating cdpedia.exe')
+    imagedir = os.path.abspath(imagedir)
+    projdir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    logger.debug('Project dir: %s', projdir)
+    logger.debug('Image dir: %s', imagedir)
+    if tempdir is None:
+        tempdir = os.path.abspath(tempfile.gettempdir())
+    tempdir = os.path.abspath(tempdir)
+    logger.debug('Temp dir: ' + tempdir)
+
+    script = os.path.join(imagedir, 'cdpedia.py')
+    templates = os.path.join(imagedir, 'cdpedia', 'src', 'web', 'templates')
+    icon = os.path.join(projdir, 'resources', 'autorun.win', 'cdroot', 'cdpedia.ico')
+    pyinstaller = os.path.join(os.environ['VIRTUAL_ENV'], 'Scripts', 'pyinstaller.exe')
+
+    cmd = [
+        pyinstaller,
+        '--onefile',
+        '--noupx',
+        '--noconsole',
+        '--paths', os.path.join(imagedir, 'cdpedia'),
+        '--paths', os.path.join(imagedir, 'cdpedia', 'extlib'),
+        '--add-data', '{};src/web/templates'.format(templates),
+        '--icon', icon,
+        '--distpath', imagedir,
+        '--specpath', tempdir,
+        '--workpath', tempdir,
+        os.path.abspath(script)
+    ]
+
+    if not subprocess.call(cmd, cwd=os.path.dirname(pyinstaller)):
+        src = os.path.join(imagedir, 'cdpedia.exe')
+        dst = os.path.join(projdir, 'resources', 'autorun.win', 'cdroot', 'cdpedia.exe')
+        shutil.copyfile(src, dst)
+        logger.info('cdpedia.exe correctly generated')
+    else:
+        logger.error('Could not generate cdpedia.exe correctly')
+
+
+if __name__ == '__main__':
+
+    logging.basicConfig(
+        level=logging.DEBUG, format='%(name)-6s %(levelname)-6s %(message)s')
+
+    build_exe(*sys.argv[1:])


### PR DESCRIPTION
Agregué un script para regenerar el exe en windows. Hice una generación de prueba y funcionó OK en Win10-x64, faltan pruebas en otras plataformas. No cierro #222 porque no incluí el exe en el PR (ocupa 10 MB), me parece mejor hacerlo justo antes del próximo release.

`pyinstaller` [no soporta py38](https://github.com/pyinstaller/pyinstaller/issues/4311) y el proceso no me convence, sobre todo por la necesidad de regenerar el exe antes de cada release. Abrí #289 describiendo una alternativa a usar pyinstaller.