### PR TITLE
Fix index creation call from cdpindex.py

### DIFF
--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -162,8 +162,8 @@ def generate_from_html(dirbase, verbose):
             ptje = 50 + score // 1000
             data = (namhtml, title, ptje, True, primtext)
             check_already_seen(data)
-            for word in WORDS.findall(normalize_words(title)):
-                yield word, data
+            words = WORDS.findall(normalize_words(title))
+            yield words, ptje, data
 
             # pass words to the redirects which points to
             # this html file, using the same score
@@ -171,8 +171,7 @@ def generate_from_html(dirbase, verbose):
                 for (words, title) in redirs[arch]:
                     data = (namhtml, title, ptje, False, "")
                     check_already_seen(data)
-                    for word in words:
-                        yield word, data
+                    yield words, ptje, data
 
             # FIXME: las siguientes lineas son en caso de que la generación
             # fuese fulltext, pero no lo es (habrá fulltext en algún momento,


### PR DESCRIPTION
The `generate_from_html` function of `cdpindex.py` was calling the `create` method of index with the wrong params.

I was getting this traceback in the log:
```
2020-08-29 18:21:26,347  generar              INFO     Generating the index
2020-08-29 18:21:26,364  src.armado.cdpindex  INFO     Adding to index: ['Portal:Portada']  ('P/o/r/Portal:Portada')
Traceback (most recent call last):
  File "cdpetron.py", line 438, in <module>
    main(
  File "cdpetron.py", line 349, in main
    generate.main(language, location.langdir, image, lang_config, gendate, verbose=test)
  File "/home/fede/cdpedia_project/cdpedia/src/generate.py", line 367, in main
    result = cdpindex.generate_from_html(articulos, verbose)
  File "/home/fede/cdpedia_project/cdpedia/src/armado/cdpindex.py", line 193, in generate_from_html
    Index.create(config.DIR_INDICE, gen())
  File "/home/fede/cdpedia_project/cdpedia/src/armado/compressed_index.py", line 525, in create
    for keys, score, data in source:
ValueError: not enough values to unpack (expected 3, got 2)
```
