### PR TITLE
CSS Scraper (1/3): Extract CSS links while scraping articles

### DIFF
--- a/cdpetron.py
+++ b/cdpetron.py
@@ -85,6 +85,7 @@ class Location(object):
         self.langdir = os.path.join(self.dumpbase, language)
         self.articles = os.path.join(self.langdir, self.ARTICLES)
         self.resources = os.path.join(self.langdir, self.RESOURCES)
+        self.cssdir = os.path.join(self.langdir, config.CSS_DIRNAME)
         self.images = os.path.join(self.dumpbase, self.IMAGES)  # language agnostic
 
         # (maybe) create all the above directories; note they are ordered!
@@ -93,6 +94,7 @@ class Location(object):
             self.langdir,
             self.articles,
             self.resources,
+            self.cssdir,
             self.images,
         ]
         for item in to_create:

--- a/config.py
+++ b/config.py
@@ -140,6 +140,12 @@ LOG_IMAGES_REQUIRED = DIR_TEMP + '/images_required.txt'
 EMBED_IMAGES = True
 LOG_IMAGES_EMBEDDED = DIR_TEMP + '/images_embed.txt'
 
+# Directory name for saving CSS stylesheets and associated resources
+CSS_DIRNAME = 'css'
+
+# filename for collecting CSS links while scraping
+CSS_LINKS_FILENAME = 'css_links.txt'
+
 # Validate translation before generating a CDPedia in the specified language.
 # Interrupt process if validation fails. In test mode, show validation result
 # but don't interrupt process.

--- a/src/scraping/scraper.py
+++ b/src/scraping/scraper.py
@@ -29,11 +29,13 @@ import logging
 import os
 import re
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 
+import config
 from src import utiles
 from src.armado import to3dirs
 
@@ -270,6 +272,44 @@ class WikipediaArticle(object):
         return False
 
 
+class CSSLinksExtractor:
+    """Extract raw CSS links from HTML source code."""
+
+    def __init__(self, language_dir):
+        # extracted data must be saved in each language's dump
+        cssdir = os.path.join(language_dir, config.CSS_DIRNAME)
+        links_file = os.path.join(cssdir, config.CSS_LINKS_FILENAME)
+        # load previously collected links if any
+        try:
+            self._fh = open(links_file, 'r+t', encoding='utf-8')
+            self.links = {line.strip() for line in self._fh}
+        except FileNotFoundError:
+            self._fh = open(links_file, 'wt', encoding='utf-8')
+            self.links = set()
+
+        # pattern for extracting css links from html
+        regex = r"/w/load.php\?.*?only=styles&amp;skin=vector"
+        self._findlinks = re.compile(regex).findall
+
+        # lock for writing to same file from different threads
+        self._lock = threading.Lock()
+
+    def close(self):
+        """Close output file handler."""
+        self._fh.close()
+
+    def __call__(self, html):
+        """Extract css links from html string."""
+        new_links = set(self._findlinks(html)) - self.links
+        if new_links:
+            self.links.update(new_links)
+            # as html head is discarded after this extraction,
+            # dump new links as soon as found to avoid data loss
+            with self._lock:
+                self._fh.write('\n'.join(new_links) + '\n')
+                self._fh.flush()
+
+
 regex = (
     r'(<h1 id="firstHeading" class="firstHeading" '
     r'lang=".+">.+</h1>)(.+)\s*<div class="printfooter">')
@@ -288,6 +328,9 @@ def get_html(url, basename):
         # unknown html format
         raise BadHTMLError("HTML file from  {!r} has an unknown format".format(url))
     stripped_html = "\n".join(found.groups())
+
+    # extract css links here as html head is not saved
+    extract_css_links(html)
 
     return stripped_html
 
@@ -393,7 +436,13 @@ def main(articles_path, language, dest_dir, namespaces_path, test_limit=None, po
     # fix namespaces in to3dirs module so we can use it in this stage
     to3dirs.namespaces = to3dirs.Namespaces(namespaces_path)
 
+    # initialize css link extractor
+    global extract_css_links
+    extract_css_links = CSSLinksExtractor(os.path.dirname(dest_dir))
+
     data_urls = URLAlizer(articles_path, dest_dir, language, test_limit)
 
     func = functools.partial(fetch, language)
     utiles.pooled_exec(func, data_urls, pool_size, known_errors=[ScraperError])
+
+    extract_css_links.close()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,77 @@
+# Copyright 2020 CDPedistas (see AUTHORS.txt)
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  https://github.com/PyAr/CDPedia/
+
+"""Tests for the article scraper."""
+
+import pytest
+
+import config
+from src.scraping.scraper import CSSLinksExtractor
+from tests.utils import load_test_article
+
+
+class TestCSSLinksExtractor:
+    """Tests for the CSS links extractor."""
+
+    @pytest.fixture
+    def css_params(self, tmp_path):
+        cssdir = tmp_path / config.CSS_DIRNAME
+        cssdir.mkdir()
+        linksfile = cssdir / config.CSS_LINKS_FILENAME
+        return str(tmp_path), linksfile
+
+    def test_match_css_links(self, css_params):
+        """Match all CSS links in HTML."""
+        langdir, _ = css_params
+        extractor = CSSLinksExtractor(langdir)
+        html, _ = load_test_article('article_with_images')
+        links = extractor._findlinks(html)
+        assert len(links) == 4
+
+    def test_init_without_previous_data(self, css_params):
+        """Set the correct defaults."""
+        langdir, _ = css_params
+        extractor = CSSLinksExtractor(langdir)
+        assert extractor.links == set()
+        assert not extractor._fh.closed
+
+    def test_init_with_previous_data(self, css_params):
+        """Load previously saved URLs."""
+        langdir, linksfile = css_params
+        links = {'eggs/bacon', 'spam'}
+        linksfile.write_text('\n'.join(links) + '\n')
+        extractor = CSSLinksExtractor(langdir)
+        assert extractor.links == links
+        assert not extractor._fh.closed
+
+    def test_closing_filehandler(self, css_params):
+        """Correctly close filehandler."""
+        langdir, _ = css_params
+        extractor = CSSLinksExtractor(langdir)
+        assert not extractor._fh.closed
+        extractor.close()
+        assert extractor._fh.closed
+
+    def test_extracting_css_links(self, css_params):
+        """Extract all CSS links from HTML and save them to file."""
+        langdir, linksfile = css_params
+        extractor = CSSLinksExtractor(langdir)
+        html, _ = load_test_article('article_with_images')
+        extractor(html)
+        assert len(extractor.links) == 4
+        extractor.close()
+        links = linksfile.read_text(encoding='utf-8')
+        assert len(links.split()) == 4

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -19,11 +19,11 @@
 import pytest
 
 import config
-from src.scraping.scraper import CSSLinksExtractor
+from src.scraping.scraper import CSSLinkExtractor
 from tests.utils import load_test_article
 
 
-class TestCSSLinksExtractor:
+class TestCSSLinkExtractor:
     """Tests for the CSS links extractor."""
 
     @pytest.fixture
@@ -33,44 +33,47 @@ class TestCSSLinksExtractor:
         linksfile = cssdir / config.CSS_LINKS_FILENAME
         return str(tmp_path), linksfile
 
-    def test_match_css_links(self, css_params):
+    def test_match_css_links(self):
         """Match all CSS links in HTML."""
-        langdir, _ = css_params
-        extractor = CSSLinksExtractor(langdir)
+        extractor = CSSLinkExtractor()
         html, _ = load_test_article('article_with_images')
         links = extractor._findlinks(html)
         assert len(links) == 4
 
-    def test_init_without_previous_data(self, css_params):
+    def test_setup_without_previous_data(self, css_params):
         """Set the correct defaults."""
         langdir, _ = css_params
-        extractor = CSSLinksExtractor(langdir)
+        extractor = CSSLinkExtractor()
+        extractor.setup(langdir)
         assert extractor.links == set()
         assert not extractor._fh.closed
 
-    def test_init_with_previous_data(self, css_params):
+    def test_setup_with_previous_data(self, css_params):
         """Load previously saved URLs."""
         langdir, linksfile = css_params
         links = {'eggs/bacon', 'spam'}
         linksfile.write_text('\n'.join(links) + '\n')
-        extractor = CSSLinksExtractor(langdir)
+        extractor = CSSLinkExtractor()
+        extractor.setup(langdir)
         assert extractor.links == links
         assert not extractor._fh.closed
 
     def test_closing_filehandler(self, css_params):
         """Correctly close filehandler."""
         langdir, _ = css_params
-        extractor = CSSLinksExtractor(langdir)
+        extractor = CSSLinkExtractor()
+        extractor.setup(langdir)
         assert not extractor._fh.closed
         extractor.close()
         assert extractor._fh.closed
 
-    def test_extracting_css_links(self, css_params):
+    def test_collect_css_links(self, css_params):
         """Extract all CSS links from HTML and save them to file."""
         langdir, linksfile = css_params
-        extractor = CSSLinksExtractor(langdir)
+        extractor = CSSLinkExtractor()
+        extractor.setup(langdir)
         html, _ = load_test_article('article_with_images')
-        extractor(html)
+        extractor.collect(html)
         assert len(extractor.links) == 4
         extractor.close()
         links = linksfile.read_text(encoding='utf-8')


### PR DESCRIPTION
Extract raw CSS links from each scraped HTML just before the `<head>` part is discarded.

Part 1/3 for addressing issue #294.