### PR TITLE
Sqliteidx plugged

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ Babel
 bs4
 flake8
 futures
-progress
 pillow
 pytest
 pytest-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ bs4
 flake8
 futures
 pillow
+progress
 pytest
 pytest-mock
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 jinja2==2.11.2
 werkzeug==1.0.1
-progress
 pyyaml==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jinja2==2.11.2
 werkzeug==1.0.1
+progress
 pyyaml==5.3.1

--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -27,23 +27,16 @@ import re
 import shutil
 import subprocess
 import threading
-import unicodedata
 import urllib.parse
 from collections import defaultdict
 
 # from .easy_index import Index
-from .compressed_index import Index
+from .sqlite_index import Index, normalize_words
 
 logger = logging.getLogger(__name__)
 
 # regex used to separate words
 WORDS = re.compile(r"\w+", re.UNICODE)
-
-
-def normalize_words(txt):
-    """Separate and normalize every word from a sentence."""
-    txt = unicodedata.normalize('NFKD', txt).encode('ASCII', 'ignore').lower().decode("ascii")
-    return txt
 
 
 def _get_html_words(arch):

--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -31,6 +31,7 @@ import urllib.parse
 from collections import defaultdict
 
 # from .easy_index import Index
+# from .compressed_index import Index
 from .sqlite_index import Index, normalize_words
 
 logger = logging.getLogger(__name__)

--- a/src/armado/compressed_index.py
+++ b/src/armado/compressed_index.py
@@ -533,7 +533,7 @@ class Index(object):
             if any([('\n' in k) for k in keys]):
                 raise ValueError("Keys cannot contain newlines")
             indexed_counter += len(keys)
-            value = list(data) + [score]
+            value = list(data)
 
             # docid -> info final
             docid = ids_cnter

--- a/src/armado/easy_index.py
+++ b/src/armado/easy_index.py
@@ -196,7 +196,7 @@ class Index(object):
             if any([('\n' in k) for k in keys]):
                 raise ValueError("Keys cannot contain newlines")
             indexed_counter += len(keys)
-            value = list(data) + [ptje]
+            value = list(data)
 
             # docid -> info final
             # don't add to tmp_reverse_id or ids_shelf if the value is repeated

--- a/src/armado/sqlite_index.py
+++ b/src/armado/sqlite_index.py
@@ -26,7 +26,6 @@ import unicodedata
 import sqlite3
 from collections import defaultdict
 from functools import lru_cache
-from progress.bar import Bar
 import lzma as best_compressor  # zlib is faster, lzma has better ratio.
 
 from src.armado import to3dirs
@@ -411,6 +410,7 @@ class Index:
         """
         import pickletools
         import time
+        from progress.bar import Bar
 
         class SQLmany:
             """Execute many INSERTs greatly improves the performance."""

--- a/src/armado/sqlite_index.py
+++ b/src/armado/sqlite_index.py
@@ -22,6 +22,7 @@ import operator
 import os
 import pickle
 import random
+import unicodedata
 import sqlite3
 from collections import defaultdict
 from functools import lru_cache
@@ -29,12 +30,17 @@ from progress.bar import Bar
 import lzma as best_compressor  # zlib is faster, lzma has better ratio.
 
 from src.armado import to3dirs
-from src.armado import cdpindex
 
 logger = logging.getLogger(__name__)
 
 PAGE_SIZE = 512
-MAX_RESULTS = 100
+MAX_RESULTS = 500
+
+
+def normalize_words(txt):
+    """Separate and normalize every word from a sentence."""
+    txt = unicodedata.normalize('NFKD', txt).encode('ASCII', 'ignore').lower().decode("ascii")
+    return txt
 
 
 def decompress_data(data):
@@ -376,11 +382,14 @@ class Index:
         return row
 
     def search(self, keys):
+        pass
+
+    def partial_search(self, keys):
         """Return all the values that are found for those keys.
 
         The AND boolean operation is applied to the keys.
         """
-        keys = list(map(cdpindex.normalize_words, keys))
+        keys = list(map(normalize_words, keys))
         files_yielded = set()
         docset = Search(self.db, keys)
         for score, ndoc in docset.ordered:
@@ -391,8 +400,6 @@ class Index:
                 yield doc_data
             if len(files_yielded) >= MAX_RESULTS:
                 break
-
-    partial_search = search
 
     @classmethod
     def create(cls, directory, source):
@@ -479,7 +486,7 @@ class Index:
             docs_table = Compressed("Documents", sql, len(source))
 
             for words, page_score, data in source:
-                data = list(data) + [page_score]
+                data = list(data)
                 if data[0] == to_filename(data[1]):
                     data[0] = None
                 docid = docs_table.append((len(words), data))

--- a/src/armado/sqlite_index.py
+++ b/src/armado/sqlite_index.py
@@ -381,6 +381,11 @@ class Index:
         return row
 
     def search(self, keys):
+        """Not implemented, just added for API compatibility.
+
+        As partial_search is fast enough, there is no need
+        to split the search in two different functions.
+        Just use partial_search instead."""
         pass
 
     def partial_search(self, keys):

--- a/utilities/convert_index.py
+++ b/utilities/convert_index.py
@@ -13,9 +13,7 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # For further info, check  https://github.com/PyAr/CDPedia/
-"""
-Creates a sqlite_index from a existing compressed_index
-"""
+"""Create a sqlite_index from a existing compressed_index."""
 
 import pathlib
 import logging

--- a/utilities/convert_index.py
+++ b/utilities/convert_index.py
@@ -1,0 +1,119 @@
+# Copyright 2020 CDPedistas (see AUTHORS.txt)
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  https://github.com/PyAr/CDPedia/
+"""
+Creates a sqlite_index from a existing compressed_index
+"""
+
+import pathlib
+import logging
+import pickle
+import re
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+from bz2 import BZ2File as CompressedFile
+sys.path.append(os.path.abspath(os.curdir))
+
+import config   # NOQA import after fixing path
+from src.armado import to3dirs  # NOQA import after fixing path
+from src.armado.sqlite_index import Index as IndexSQL  # NOQA import after fixing path
+from src.armado.cdpindex import normalize_words  # NOQA import after fixing path
+
+logger = logging.getLogger()
+handler = logging.StreamHandler()
+logger.addHandler(handler)
+formatter = logging.Formatter("%(asctime)s  %(name)-20s %(levelname)-8s %(message)s")
+handler.setFormatter(formatter)
+logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
+handler = RotatingFileHandler("cdpetron.log")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger = logging.getLogger("index")
+
+WORDS = re.compile(r"\w+", re.UNICODE)
+PATH_IDX = pathlib.Path("./idx")
+PATH_COMP = PATH_IDX.joinpath("old")
+
+
+def walk():
+    # see how many id files we have
+    for fn in os.listdir(PATH_COMP):
+        if fn.startswith("compindex-") and fn.endswith(".ids.bz2"):
+            yield str(PATH_COMP.joinpath(fn))
+
+
+def decomp(fname):
+    """Decompress a file and return a dict."""
+    fh = CompressedFile(fname, "rb")
+    # encoding needed for compatibility w/ py2 cPickle
+    idx = pickle.load(fh, encoding="latin1")
+    fh.close()
+    return idx
+
+
+def cycle():
+    """Loop & open every file and yield every value inside."""
+    for fname in walk():
+        idx = decomp(fname)
+        # print(fname, len(idx))
+        print("!", end="", flush=True)
+        for n_doc, value in idx.items():
+            html, title, ptje, redir, primtext = value
+            words = list(WORDS.findall(normalize_words(title)))
+            yield words, ptje, (html, title, ptje, redir, primtext)
+
+
+def cycle_filtered():
+    """ Avoid any null or repeated entry, just for security."""
+    alreadyseen = set()
+    repeated = null_title = 0
+    for words, ptje, data in cycle():
+        hash_data = hash(data)
+        if hash_data not in alreadyseen:
+            alreadyseen.add(hash_data)
+            if data[1]:
+                yield words, ptje, data
+            else:
+                null_title += 1
+        else:
+            repeated += 1
+    print("\nnull_title", null_title, "  repeated", repeated)
+
+
+def test_cycle():
+    """See what is bringing."""
+    for n_doc, value in enumerate(cycle()):
+        print(value)
+        if n_doc > 5:
+            break
+
+
+def main():
+    help = """Creates a new sqlite index from the compressed index information.
+
+    Sqlite index path: '%s'    Legacy compressed index path: '%s'""" % (PATH_IDX, PATH_COMP)
+    print(help)
+    sqlitepath = PATH_IDX.joinpath("index.sqlite")
+    if sqlitepath.exists():
+        sqlitepath.unlink()
+        print("Database index %s was removed" % sqlitepath)
+    IndexSQL.create(str(PATH_IDX), cycle_filtered())
+
+
+if __name__ == "__main__":
+    # media_words()
+    main()

--- a/utilities/search_index.py
+++ b/utilities/search_index.py
@@ -1,0 +1,79 @@
+# -*- encoding: utf8 -*-
+
+# Copyright 2009-2020 CDPedistas (see AUTHORS.txt)
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  https://github.com/PyAr/CDPedia/
+
+import os
+import sys
+import argparse
+import timeit
+sys.path.append(os.path.abspath(os.curdir))
+
+from src.armado.sqlite_index import Index # NOQA import after fixing path
+
+PAGE = 50
+
+
+def output(*out):
+    if args.file:
+        with open(args.file, "a") as fn:
+            print(*out, file=fn)
+    print(*out)
+
+
+def show_results(result):
+    def show_stat(definition, value):
+        output("{:>25}:{}".format(definition, value))
+
+    first_res_time = 0
+    for nro, (namhtml, title, ptje, redir, primtext) in enumerate(result):
+        if nro == 0:
+            first_res_time = timeit.default_timer() - initial_time
+            show_stat("First Result", first_res_time)
+        if args.verbose and nro <= PAGE:
+            # pp(row)
+            output('{0:2d}){2:8d} "{1:30s}" {3:70s}'.format(
+                nro, title, ptje, primtext[:70].replace("\n", " ")))
+        if nro == PAGE:
+            first_res_time = timeit.default_timer() - initial_time
+            show_stat("First %d Result" % PAGE, first_res_time)
+    show_stat("Time", timeit.default_timer() - initial_time)
+    show_stat("Results", nro + 1)
+    return
+
+
+if __name__ == "__main__":
+    help = """Search some words and compare results in different indexes.
+
+    Uses .idx as default path to index."""
+
+    parser = argparse.ArgumentParser(description=help)
+    parser.add_argument('keys', metavar='word', type=str, nargs='+',
+                        help='strings to search')
+    parser.add_argument('-f', '--file', dest='file', help="append to a file")
+    parser.add_argument('-p', '--path', dest='path',
+                        default="./idx", help="Index's db path")
+    parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
+                        default=False, help="Show detailed results")
+    args = parser.parse_args()
+    initial_time = timeit.default_timer()
+    idx = Index(args.path)
+    output(repr(Index), "   keys=", args.keys)
+    delta_time = timeit.default_timer() - initial_time
+    output("Open Time: ", delta_time * 100)
+    initial_time = timeit.default_timer()
+    res = idx.partial_search(args.keys)
+    show_results(res)

--- a/utilities/search_index.py
+++ b/utilities/search_index.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf8 -*-
-
 # Copyright 2009-2020 CDPedistas (see AUTHORS.txt)
 #
 # This program is free software: you can redistribute it and/or modify it
@@ -15,6 +13,7 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # For further info, check  https://github.com/PyAr/CDPedia/
+"""Search text into the index from command-line."""
 
 import os
 import sys


### PR DESCRIPTION
Some comments
- Deleted duplicated data of ptje. It was added ages ago to simplify debugging. It's not needed.
- This was the reason of most of changes in test_index.py. It was needed to avoid check ptje as last item in result.
- The API of easy_index, compressed_index and sqlite_index are not fully compatible. I renamed search to partial_search, and leave just a void function on search. 
- I changed the total max number of results provided by sqlite_index. In the GUI, there are a link that gives to the user 500 results by page, so that was the new limit.

Enjoy! #310
