### PR TITLE
Parte 1 de los cambios para separar dev de prod

### DIFF
--- a/cdpetron.py
+++ b/cdpetron.py
@@ -49,7 +49,6 @@ URL_LIST = (
 )
 ART_ALL = "all_articles.txt"
 DATE_FILENAME = "start_date.txt"
-NAMESPACES = "namespace_prefixes.txt"
 PORTAL_PAGES = 'portal_pages.txt'
 
 # some limits when running in test mode
@@ -165,10 +164,7 @@ def get_lists(language, lang_config, test):
     logger.info("Got %d namespace articles", q)
 
     # save the namespace prefixes
-    _path = os.path.join(location.resources, NAMESPACES)
-    with open(_path, 'wt', encoding="utf-8") as fh:
-        for prefix in sorted(prefixes):
-            fh.write(prefix + "\n")
+    to3dirs.namespaces.dump(prefixes, location.resources)
 
     q = 0
     for page in lang_config['include']:
@@ -211,9 +207,8 @@ def load_creation_date():
 def _call_scraper(language, articles_file, test=False):
     """Prepare the command and run scraper.py."""
     logger.info("Let's scrap (with limit=%s)", test)
-    namespaces_path = os.path.join(location.resources, NAMESPACES)
     limit = TEST_LIMIT_SCRAP if test else None
-    scraper.main(articles_file, language, location.articles, namespaces_path, test_limit=limit)
+    scraper.main(articles_file, language, location.articles, test_limit=limit)
 
 
 def scrap_pages(language, test):
@@ -314,6 +309,9 @@ def main(language, lang_config, imag_config,
             return
     else:
         gendate = get_lists(language, lang_config, test)
+
+    # at this point we have the namespaces in disk, let's init them
+    to3dirs.namespaces.load(location.resources)
 
     if not noscrap:
         scrap_portal(language, lang_config)

--- a/config.py
+++ b/config.py
@@ -67,11 +67,6 @@ if EDICION_ESPECIAL is not None:
 # Si no hay destacados debe ser None
 DESTACADOS = None
 
-# Para revisar la página inicial de CDPedia con cada artículo destacado se
-# debe poner esta variable en True y cada vez que se cargué la página inicial
-# se irán mostrando en orden los destacados.
-DEBUG_DESTACADOS = False
-
 # Tiempo de espera máxima, en segundos, para actualización del browser_watchdog.
 # Usar BROWSER_WD_SECONDS = 0 para desactivar el watchdog.
 BROWSER_WD_SECONDS = 120
@@ -82,6 +77,7 @@ SEARCH_RESULTS = 20
 # info para el compresor / decompresor
 ARTICLES_PER_BLOCK = 2000
 DIR_BLOQUES = "temp/bloques"
+DIR_IMGBLOQUES = "temp/imgbloques"
 
 # Directorio de archivos temporales
 DIR_TEMP = "temp"
@@ -105,7 +101,7 @@ IMAGES_PER_BLOCK = 200
 DIR_CDBASE = "temp/cdroot"
 
 # Directorio de los archivos estáticos: imagenes, hojas de estilo, etc
-DIR_ASSETS = "temp/cdroot/cdpedia/assets"
+DIR_ASSETS = "temp/cdroot/assets"
 
 # Directorio de los archivos estáticos de origen
 DIR_SOURCE_ASSETS = "resources"
@@ -150,11 +146,6 @@ SEPARADOR_COLUMNAS = '|'
 
 # Tag de que la info viene de un recurso dinámico de mucha importancia
 DYNAMIC = '__dynamic__'
-
-# Comando externo para convertir en HTML en texto, para extraer las palabras
-# del documento. Lynx es el default, pero requiere que esté instalado en el host.
-# W3m está disponible en todos los Ubuntus. %s se expande al path al archivo
-CMD_HTML_A_TEXTO = 'w3m -dump -T "text/html" -I utf-8 -O utf-8 -s -F -no-graph %s'
 
 # load configuration for languages and validate
 _path = os.path.join(os.path.dirname(__file__), "imagtypes.yaml")

--- a/run
+++ b/run
@@ -1,1 +1,3 @@
-fades -r requirements.txt cdpedia.py
+# run the "production" cdpedia inside a venv with no dependencies installed, so we're 
+# sure everything is properly taken from itself or included external libraries
+fades temp/cdroot/cdpedia.py

--- a/src/armado/compresor.py
+++ b/src/armado/compresor.py
@@ -73,12 +73,12 @@ class BloqueManager(object):
         self.verbose = verbose
 
     @classmethod
-    def _prep_archive_dir(self, lang=None):
+    def _prep_archive_dir(cls, lang=None):
         """Prepare the directory for the archive."""
         # prepare the destination dir
-        if os.path.exists(self.archive_dir):
-            shutil.rmtree(self.archive_dir)
-        os.makedirs(self.archive_dir)
+        if os.path.exists(cls.archive_dir):
+            shutil.rmtree(cls.archive_dir)
+        os.makedirs(cls.archive_dir)
 
         # save the language of the blocks, if any
         if lang is not None:
@@ -86,9 +86,9 @@ class BloqueManager(object):
                 fh.write(lang + '\n')
 
     @classmethod
-    def guardarNumBloques(self, cant):
+    def guardarNumBloques(cls, cant):
         """Save to disk the quantity of blocks."""
-        fname = os.path.join(self.archive_dir, 'numbloques.txt')
+        fname = os.path.join(cls.archive_dir, 'numbloques.txt')
         with open(fname, 'wt', encoding='ascii') as fh:
             fh.write(str(cant) + '\n')
 
@@ -156,7 +156,7 @@ class BloqueImagenes(Bloque):
         self.manager = manager
 
     @classmethod
-    def crear(self, bloqNum, fileNames, verbose=False):
+    def crear(cls, bloqNum, fileNames, verbose=False):
         """Generate the file."""
         logger.debug("Processing block of images %s", bloqNum)
 
@@ -177,7 +177,7 @@ class BloqueImagenes(Bloque):
             len(fileNames), seek, len(headerBytes))
 
         # open the file to compress
-        nomfile = os.path.join(config.DIR_ASSETS, 'images', "%08x.cdi" % bloqNum)
+        nomfile = os.path.join(config.DIR_IMGBLOQUES, "%08x.cdi" % bloqNum)
         logger.debug("  saving in %s", nomfile)
 
         with open(nomfile, "wb") as dst_fh:
@@ -212,7 +212,7 @@ class Comprimido(Bloque):
         self.manager = manager
 
     @classmethod
-    def crear(self, redirects, bloqNum, top_filenames, verbose=False):
+    def crear(cls, redirects, bloqNum, top_filenames, verbose=False):
         """Generate the compressed file."""
         logger.debug("Processing block %s", bloqNum)
 
@@ -259,8 +259,8 @@ class ArticleManager(BloqueManager):
     items_per_block = config.ARTICLES_PER_BLOCK
 
     @classmethod
-    def generar_bloques(self, lang, verbose):
-        self._prep_archive_dir(lang)
+    def generar_bloques(cls, lang, verbose):
+        cls._prep_archive_dir(lang)
 
         # import this here as it's not needed in production
         from src.preprocessing import preprocess
@@ -270,8 +270,8 @@ class ArticleManager(BloqueManager):
         top_pages = preprocess.pages_selector.top_pages
         logger.debug("Processing %d articles", len(top_pages))
 
-        numBloques = len(top_pages) // self.items_per_block + 1
-        self.guardarNumBloques(numBloques)
+        numBloques = len(top_pages) // cls.items_per_block + 1
+        cls.guardarNumBloques(numBloques)
         bloques = {}
         all_filenames = set()
         for dir3, filename, _ in top_pages:
@@ -323,14 +323,14 @@ class ArticleManager(BloqueManager):
 
 
 class ImageManager(BloqueManager):
-    archive_dir = os.path.join(config.DIR_ASSETS, 'images')
+    archive_dir = config.DIR_IMGBLOQUES
     archive_extension = ".cdi"
     archive_class = BloqueImagenes
     items_per_block = config.IMAGES_PER_BLOCK
 
     @classmethod
-    def generar_bloques(self, verbose):
-        self._prep_archive_dir()
+    def generar_bloques(cls, verbose):
+        cls._prep_archive_dir()
 
         # get all the images, and store them in a dict using its block number, calculated
         # wiht a hash of the name
@@ -341,8 +341,8 @@ class ImageManager(BloqueManager):
                 fileNames.append(name)
         logger.debug("Processing %d images", len(fileNames))
 
-        numBloques = len(fileNames) // self.items_per_block + 1
-        self.guardarNumBloques(numBloques)
+        numBloques = len(fileNames) // cls.items_per_block + 1
+        cls.guardarNumBloques(numBloques)
         bloques = {}
         for fileName in fileNames:
             bloqNum = utiles.coherent_hash(fileName.encode('utf8')) % numBloques

--- a/src/armado/to3dirs.py
+++ b/src/armado/to3dirs.py
@@ -36,7 +36,7 @@ QUOTER = {c: '%{:02X}'.format(ord(c)) for c in './%'}
 
 
 class Namespaces:
-    """A list of namespaces initted from different sources."""
+    """A list of namespaces initiated from different sources."""
 
     _fname = 'namespace_prefixes.txt'
 
@@ -58,7 +58,7 @@ class Namespaces:
 
     def __contains__(self, tocheck):
         if self._namespaces is None:
-            raise RuntimeError("Namespaces not initted.")
+            raise RuntimeError("Namespaces not initiated.")
 
         return tocheck in self._namespaces
 

--- a/src/armado/to3dirs.py
+++ b/src/armado/to3dirs.py
@@ -30,26 +30,35 @@ Current implementation complies with two needs:
 import os
 from urllib.parse import unquote
 
-import config
-
 NULL = "_"
 
 QUOTER = {c: '%{:02X}'.format(ord(c)) for c in './%'}
 
 
-class Namespaces(object):
-    """A dynamic loading list of namespaces."""
-    def __init__(self, path=None):
+class Namespaces:
+    """A list of namespaces initted from different sources."""
+
+    _fname = 'namespace_prefixes.txt'
+
+    def __init__(self):
         self._namespaces = None
-        if path is None:
-            self.filepath = os.path.join(config.DIR_ASSETS, 'dynamic', "namespace_prefixes.txt")
-        else:
-            self.filepath = path
+
+    def load(self, dirbase):
+        """Load the info from the file in the specified directory."""
+        path = os.path.join(dirbase, self._fname)
+        with open(path, 'rt', encoding='utf8') as fh:
+            self._namespaces = {x.strip() for x in fh}
+
+    def dump(self, prefixes, dirbase):
+        """Dump the given information to file in the specified directory."""
+        path = os.path.join(dirbase, self._fname)
+        with open(path, 'wt', encoding="utf-8") as fh:
+            for prefix in sorted(prefixes):
+                fh.write(prefix + "\n")
 
     def __contains__(self, tocheck):
         if self._namespaces is None:
-            with open(self.filepath, 'rt', encoding='utf8') as fh:
-                self._namespaces = set(x.strip() for x in fh)
+            raise RuntimeError("Namespaces not initted.")
 
         return tocheck in self._namespaces
 

--- a/src/generate.py
+++ b/src/generate.py
@@ -76,7 +76,7 @@ def make_it_nicer():
 def copy_dir(src_dir, dst_dir):
     """Copy a directory recursively.
 
-    Will copy everything except '.pyc' and '.*'.
+    Will copy everything except compiled Python and hidden files
     """
     if not os.path.exists(dst_dir):
         os.mkdir(dst_dir)

--- a/src/generate.py
+++ b/src/generate.py
@@ -48,6 +48,14 @@ if sys.stdout.encoding is None:
 logger = logging.getLogger('generar')
 
 
+def link(src, dst):
+    """Create a hard link, like os.link, only if needed."""
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+    if not os.path.exists(dst):
+        os.link(src, dst)
+
+
 def make_it_nicer():
     """Make the process nicer at CPU and IO levels."""
     # cpu, simple
@@ -75,14 +83,14 @@ def copy_dir(src_dir, dst_dir):
     for fname in os.listdir(src_dir):
         if fname.startswith("."):
             continue
-        if fname.endswith('.pyc'):
+        if fname.endswith('.pyc') or fname == "__pycache__":
             continue
         src_path = path.join(src_dir, fname)
         dst_path = path.join(dst_dir, fname)
         if path.isdir(src_path):
             copy_dir(src_path, dst_path)
         else:
-            shutil.copy(src_path, dst_path)
+            link(src_path, dst_path)
 
 
 def copy_assets(src_info, dest):
@@ -105,7 +113,7 @@ def copy_assets(src_info, dest):
     # general info
     src_dir = "resources/general_info"
     copy_dir(src_dir, config.DIR_CDBASE)
-    shutil.copy('AUTHORS.txt', os.path.join(config.DIR_CDBASE, 'AUTORES.txt'))
+    link('AUTHORS.txt', os.path.join(config.DIR_CDBASE, 'AUTORES.txt'))
 
     # institutional
     src_dir = "resources/institucional"
@@ -121,25 +129,23 @@ def copy_assets(src_info, dest):
 def copy_sources():
     """Copy the source code files."""
     # el src
-    dest_src = path.join(config.DIR_CDBASE, "cdpedia", "src")
+    dest_src = path.join(config.DIR_CDBASE, "src")
     clean_dir(dest_src)
-    shutil.copy(path.join("src", "__init__.py"), dest_src)
-    shutil.copy(path.join("src", "utiles.py"), dest_src)
-    copy_dir(path.join("src", "armado"),
-             path.join(config.DIR_CDBASE, "cdpedia", "src", "armado"))
-    copy_dir(path.join("src", "web"),
-             path.join(config.DIR_CDBASE, "cdpedia", "src", "web"))
+    link(path.join("src", "__init__.py"), dest_src)
+    link(path.join("src", "utiles.py"), dest_src)
+    copy_dir(path.join("src", "armado"), path.join(dest_src, "armado"))
+    copy_dir(path.join("src", "web"), path.join(dest_src, "web"))
 
     # el main va al root
-    shutil.copy("cdpedia.py", config.DIR_CDBASE)
+    link(path.join("src", "cdpedia.py"), config.DIR_CDBASE)
 
     if config.DESTACADOS:
-        shutil.copy(config.DESTACADOS, os.path.join(config.DIR_CDBASE, "cdpedia"))
+        link(config.DESTACADOS, config.DIR_CDBASE)
 
 
 def generate_libs():
     """Generate all needed libs."""
-    dest_src = path.join(config.DIR_CDBASE, "cdpedia", "extlib")
+    dest_src = path.join(config.DIR_CDBASE, "extlib")
     cmd = [
         'pip', 'install',  # base command
         '--target={}'.format(dest_src),  # put all the resulting files in that specific dir
@@ -172,8 +178,7 @@ def build_iso(dest):
 
 def gen_run_config(lang_config):
     """Generate the config file used on the final user computer."""
-    featured = os.path.join("cdpedia", config.DESTACADOS) if config.DESTACADOS else None
-    f = open(path.join(config.DIR_CDBASE, "cdpedia", "config.py"), "w")
+    f = open(path.join(config.DIR_CDBASE, "config.py"), "w")
     f.write('import os\n\n')
     f.write('VERSION = %s\n' % repr(config.VERSION))
     f.write('SERVER_MODE = %s\n' % config.SERVER_MODE)
@@ -183,18 +188,20 @@ def gen_run_config(lang_config):
     f.write('PORTAL_PAGE = "%s"\n' % lang_config['portal_index'])
     f.write('ASSETS = %s\n' % config.ASSETS)
     f.write('ALL_ASSETS = %s\n' % config.ALL_ASSETS)
-    f.write('DESTACADOS = {}\n'.format(featured))
+    f.write('DESTACADOS = {}\n'.format(config.DESTACADOS))
     f.write('BROWSER_WD_SECONDS = %d\n' % config.BROWSER_WD_SECONDS)
     f.write('SEARCH_RESULTS = %d\n' % config.SEARCH_RESULTS)
     f.write('LANGUAGE = "%s"\n' % config.LANGUAGE)
     f.write('URL_WIKIPEDIA = "%s"\n' % config.URL_WIKIPEDIA)
     f.write('PYTHON_DOCS_FILENAME = "%s"\n' % config.PYTHON_DOCS_FILENAME)
     f.write('LOCALE = "%s"\n' % os.environ['LANGUAGE'])
-    f.write('DIR_BLOQUES = os.path.join("cdpedia", "bloques")\n')
-    f.write('DIR_ASSETS = os.path.join("cdpedia", "assets")\n')
-    f.write('DIR_INDICE = os.path.join("cdpedia", "indice")\n')
+    f.write('DIR_BLOQUES = "bloques"\n')
+    f.write('DIR_IMGBLOQUES = "images"\n')
+    f.write('DIR_ASSETS = "assets"\n')
+    f.write('DIR_INDICE = "indice"\n')
     f.write('IMAGES_PER_BLOCK = %d\n' % config.IMAGES_PER_BLOCK)
     f.write('ARTICLES_PER_BLOCK = %d\n' % config.ARTICLES_PER_BLOCK)
+    f.write('NAMESPACES_PREFIXES_DIR = os.path.join("assets", "dynamic")\n')
     f.close()
 
 
@@ -204,7 +211,7 @@ def prepare_temporary_dirs(process_articles):
     if os.path.exists(dtemp):
         if not process_articles:
             # preparamos paths y vemos que todo esté ok
-            src_indices = path.join(config.DIR_CDBASE, "cdpedia", "indice")
+            src_indices = path.join(config.DIR_CDBASE, "indice")
             src_bloques = config.DIR_BLOQUES
             if not os.path.exists(src_indices):
                 logger.error("Want to avoid article processing but didn't "
@@ -221,7 +228,6 @@ def prepare_temporary_dirs(process_articles):
             os.rename(src_indices, tmp_indices)
             os.rename(src_bloques, tmp_bloques)
             shutil.rmtree(path.join(dtemp, "cdroot"), ignore_errors=True)
-            os.makedirs(path.join(config.DIR_CDBASE, "cdpedia"))
             os.rename(tmp_indices, src_indices)
             os.rename(tmp_bloques, src_bloques)
 
@@ -246,25 +252,6 @@ def build_tarball(tarball_name):
 
     # remove the symlink
     os.remove(nice_name)
-
-
-def update_mini(image_path):
-    """Update cdpedia image using code + assets in current working copy."""
-    # chequeo no estricto image_path apunta a una imagen de cdpedia
-    deberia_estar = [image_path, 'cdpedia', 'bloques', '00000000.cdp']
-    if not os.path.exists(os.path.join(*deberia_estar)):
-        logger.error("The directory doesn't look like a CDPedia image.")
-        raise EnvironmentError("CDPedia image not found, can't continue")
-
-    # adapt some config paths
-    old_top_dir = config.DIR_CDBASE
-    new_top_dir = image_path
-    config.DIR_CDBASE = config.DIR_CDBASE.replace(old_top_dir, new_top_dir)
-    config.DIR_ASSETS = config.DIR_ASSETS.replace(old_top_dir, new_top_dir)
-
-    copy_sources()
-    src_info = ''
-    copy_assets(src_info, os.path.join(new_top_dir, 'cdpedia', 'assets'))
 
 
 def main(lang, src_info, version, lang_config, gendate,
@@ -308,9 +295,9 @@ def main(lang, src_info, version, lang_config, gendate,
     prepare_temporary_dirs(process_articles)
 
     logger.info("Copying the assets and locale files")
-    copy_assets(src_info, config.DIR_ASSETS)
-    shutil.copy(os.path.join(src_info, 'portal_pages.txt'), config.DIR_TEMP)
-    shutil.copytree('locale', path.join(config.DIR_CDBASE, "locale"))
+    copy_assets(src_info, os.path.join(config.DIR_CDBASE, 'assets'))
+    link(os.path.join(src_info, 'portal_pages.txt'), config.DIR_TEMP)
+    copy_dir('locale', path.join(config.DIR_CDBASE, "locale"))
     set_locale(lang_config.get('second_language'), record=True)
 
     articulos = path.join(src_info, "articles")
@@ -374,12 +361,17 @@ def main(lang, src_info, version, lang_config, gendate,
 
     logger.info("Generating the links to blocks and indexes")
     # blocks
-    dest = path.join(config.DIR_CDBASE, "cdpedia", "bloques")
+    dest = path.join(config.DIR_CDBASE, "bloques")
     if os.path.exists(dest):
         os.remove(dest)
     os.symlink(path.abspath(config.DIR_BLOQUES), dest)
+    # images blocks
+    dest = path.join(config.DIR_CDBASE, "images")
+    if os.path.exists(dest):
+        os.remove(dest)
+    os.symlink(path.abspath(config.DIR_IMGBLOQUES), dest)
     # indexes
-    dest = path.join(config.DIR_CDBASE, "cdpedia", "indice")
+    dest = path.join(config.DIR_CDBASE, "indice")
     if os.path.exists(dest):
         os.remove(dest)
     os.symlink(path.abspath(config.DIR_INDICE), dest)
@@ -443,9 +435,6 @@ To update an image with the code and assets changes  in this working copy:
     parser.add_option("-g", "--guppy", action="store_true",
                       dest="guppy", help="arranca con guppy/heapy prendido")
 
-    parser.add_option("--update-mini", action="store_true", dest="update_mini",
-                      help="Actualiza una imagen con el code + assets de esta working copy.")
-
     (options, args) = parser.parse_args()
 
     if len(args) != 3:
@@ -488,8 +477,5 @@ To update an image with the code and assets changes  in this working copy:
             print("ERROR: there's no %r in 'languages.yaml'" % (lang,))
             exit()
 
-    if options.update_mini:
-        update_mini(direct)
-    else:
-        gendate = datetime.date.today().strftime("%Y%m%d")
-        main(lang, direct, version, lang_config, gendate, verbose, desconectado, process_articles)
+    gendate = datetime.date.today().strftime("%Y%m%d")
+    main(lang, direct, version, lang_config, gendate, verbose, desconectado, process_articles)

--- a/src/scraping/scraper.py
+++ b/src/scraping/scraper.py
@@ -379,20 +379,16 @@ def fetch(language, data_url):
         os.rename(temp_file.name, disk_name.encode("utf-8"))
 
 
-def main(articles_path, language, dest_dir, namespaces_path, test_limit=None, pool_size=20):
+def main(articles_path, language, dest_dir, test_limit=None, pool_size=20):
     """Main entry point.
 
     Params:
     - articles_path: the path to the file with the list of articles to download
     - language: the language of the Wikipedia to use (e.g.: 'es')
     - dest_dir: the destination directory to put the downloaded articles (may take tens of GBs)
-    - namespaces_path: the path to a file with the namespace prefixes
     - test_limit: a limit to how many articles download (optional, defaults to all)
     - pool_size: how many concurrent downloaders use (optional, defaults to 20)
     """
-    # fix namespaces in to3dirs module so we can use it in this stage
-    to3dirs.namespaces = to3dirs.Namespaces(namespaces_path)
-
     data_urls = URLAlizer(articles_path, dest_dir, language, test_limit)
 
     func = functools.partial(fetch, language)

--- a/tests/test_cdpedia.py
+++ b/tests/test_cdpedia.py
@@ -14,10 +14,24 @@
 #
 # For further info, check  https://github.com/PyAr/CDPedia/
 
-import cdpedia
+import os
+
+
 import config
 
 import pytest
+
+
+# importing cdpedia.py will change current working directory, so let's store and
+# put it back after all tests here are run
+_init_dir = os.getcwd()
+
+from src import cdpedia  # NOQA (importing not at the top)
+
+
+def teardown_module(module):
+    """Restore original directory."""
+    os.chdir(_init_dir)
 
 
 @pytest.fixture

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -25,7 +25,7 @@ from flake8.api.legacy import get_style_guide
 
 def _get_python_filepaths():
     """Helper to retrieve paths of Python files."""
-    python_paths = ['cdpedia.py', 'config.py', 'cdpetron.py']
+    python_paths = ['config.py', 'cdpetron.py']
     for root in ['src', 'utilities', 'tests']:
         for dirpath, dirnames, filenames in os.walk(root):
             for filename in filenames:

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -22,18 +22,20 @@ import os
 from PIL import Image
 from src.images.scale import scale_image
 
-ORIGINAL = os.path.join(os.getcwd(), 'tests', 'fixtures', 'image-to-scale.jpg')
-SCALED = os.path.join(os.getcwd(), 'tests', 'fixtures', 'scaled-image.jpg')
-
 
 class ScaleImagesTestCase(unittest.TestCase):
     """Tests for Scale."""
 
+    def setUp(self):
+        super().setUp()
+        self.original = os.path.join(os.getcwd(), 'tests', 'fixtures', 'image-to-scale.jpg')
+        self.scaled = os.path.join(os.getcwd(), 'tests', 'fixtures', 'scaled-image.jpg')
+
     def test_scale(self):
-        scale_image(ORIGINAL, SCALED, 50)
-        img = Image.open(SCALED)
+        scale_image(self.original, self.scaled, 50)
+        img = Image.open(self.scaled)
         resized_size = img.size
         self.assertEqual(resized_size, (25, 25))
 
     def tearDown(self):
-        os.remove(SCALED)
+        os.remove(self.scaled)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -36,7 +36,7 @@ def create_app_client(mocker, tmp_path):
     """Helper to create tests app and client."""
 
     # fix config and write some setup files
-    mocker.patch('config.DIR_ASSETS', str(tmp_path))
+    config.DIR_ASSETS = str(tmp_path)
     mocker.patch('config.LANGUAGE', 'es')
     mocker.patch('config.PORTAL_PAGE', 'Portal:Portal')
     mocker.patch('config.URL_WIKIPEDIA', 'http://es.wikipedia.org/')


### PR DESCRIPTION
Millón de pequeños cambios para empezar a separar "dev" de "producción". Esto es parte de un branch un poco más largo, así que algunas cosas estén "cambiadas por la mitad", pero igual tienen sentido.

Entre todo:

1. el 'namespace_prefixes.txt' es ahora responsabilidad de la estructura Namespaces, en el módulo to3dirs.

    - se la inicializa desde dos lugares (cdpetron y cdpedia), indicándole el directorio donde está

    - cdpetron no graba más eso a lo bruto, se lo indica a Namespaces

    - el scraper no tiene más nada que hacer al respecto, porque Namespaces ya está inicializado

1. agregué un DIR_IMGBLOQUES que luego voy a sacar cuando refactoree bien los directorios de los bloques (segunda parte de este branch)

1. borré porque no se usaban:

    - `DEBUG_DESTACADOS` (ni siquiera tenemos "destacados" hoy en día)

    - `CMD_HTML_A_TEXTO` (porque limpié un poco el cdpindex.py de algo que no se usaba)

1. aplané la estructura final del disco, ahora no hay un dir "cdpedia", traje todo al root

1. ahora el "run" que usamos desde desarrollo ejecuta directamente el "cdpedia final"

1. puse "cls" como primer parámetro en los "métodos de clase" del compresor.py

1. mejoré/limpié los imports en cdpedia.py, y la moví a dentro de src

1. algunas mejoras en el generate.py:

    - evitamos copiar los `__pycache__`

    - en vez de copiar archivos, hago un link (mucho más rápido!)

    - borré la función "update mini" porque no se usaba (ni sé si funcionaba ok, y me pareció peligroso que actualice una cosa sin la otra)
