### PR TITLE
Mejorar la tokenización de los títulos al generar entradas de índice

### DIFF
--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -101,7 +101,7 @@ def tokenize_title(title):
     # strip parenthesis from words, for titles like 'Grañón (La Rioja)'
     words = set(w.strip('()') for w in title_norm.split())
     words.update(WORDS.findall(title_norm))
-    return list(words)
+    return words
 
 
 def generate_from_html(dirbase, verbose):

--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -95,6 +95,15 @@ def filename2words(fname):
     return p, t
 
 
+def tokenize_title(title):
+    """Create list of tokens from given title."""
+    title_norm = normalize_words(title)
+    # strip parenthesis from words, for titles like 'Grañón (La Rioja)'
+    words = set(w.strip('()') for w in title_norm.split())
+    words.update(WORDS.findall(title_norm))
+    return list(words)
+
+
 def generate_from_html(dirbase, verbose):
     """Creates the index. used to create new versions of cdpedia."""
     # This isn't needed on the final user, so it is imported here
@@ -140,7 +149,7 @@ def generate_from_html(dirbase, verbose):
             ptje = 50 + score // 1000
             data = (namhtml, title, ptje, True, primtext)
             check_already_seen(data)
-            words = WORDS.findall(normalize_words(title))
+            words = tokenize_title(title)
             yield words, ptje, data
 
             # pass words to the redirects which points to

--- a/src/armado/sqlite_index.py
+++ b/src/armado/sqlite_index.py
@@ -35,6 +35,9 @@ logger = logging.getLogger(__name__)
 PAGE_SIZE = 512
 MAX_RESULTS = 500
 
+# cache for normalized chars
+_normalized_chars = {}
+
 
 def normalize_words(txt):
     """Normalize every word from a sentence.
@@ -45,9 +48,18 @@ def normalize_words(txt):
     """
     # decompose unicode chars
     txt = unicodedata.normalize('NFKD', txt)
-    # remove diacritics from decomposed string
-    txt = ''.join(c.lower() for c in txt if not unicodedata.combining(c))
-    return txt
+
+    # construct normalized text
+    txt_norm = []
+    for c in txt:
+        try:
+            c_norm = _normalized_chars[c]
+        except KeyError:
+            c_norm = '' if unicodedata.combining(c) else c.lower()
+            _normalized_chars[c] = c_norm
+        txt_norm.append(c_norm)
+
+    return ''.join(txt_norm)
 
 
 def decompress_data(data):

--- a/src/armado/sqlite_index.py
+++ b/src/armado/sqlite_index.py
@@ -37,8 +37,16 @@ MAX_RESULTS = 500
 
 
 def normalize_words(txt):
-    """Separate and normalize every word from a sentence."""
-    txt = unicodedata.normalize('NFKD', txt).encode('ASCII', 'ignore').lower().decode("ascii")
+    """Normalize every word from a sentence.
+
+    - remove all diacritical marks
+    - convert all letters to lowercase
+    - keep non-ascii chars to support non-latin alphabets
+    """
+    # decompose unicode chars
+    txt = unicodedata.normalize('NFKD', txt)
+    # remove diacritics from decomposed string
+    txt = ''.join(c.lower() for c in txt if not unicodedata.combining(c))
     return txt
 
 

--- a/tests/test_cdpindex.py
+++ b/tests/test_cdpindex.py
@@ -46,10 +46,18 @@ def data(mocker, tmp_path):
         pass
 
 
-@pytest.mark.parametrize('text', ('Foo', 'FOO', 'Fóó', 'fòÕ'))
-def test_word_normalization(text):
-    expected = 'foo'
-    assert expected == cdpindex.normalize_words(text)
+@pytest.mark.parametrize('text_raw, text_norm', (
+    ('FOO', 'foo'),
+    ('FóÕ', 'foo'),
+    ('ñandú', 'nandu'),
+    ('.com', '.com'),
+    ('AC/DC', 'ac/dc'),
+    ('замо́к', 'замок'),
+    ('παϊδάκια', 'παιδακια'),
+))
+def test_word_normalization(text_raw, text_norm):
+    """Check lowercase convertion and diacritics removal."""
+    assert text_norm == cdpindex.normalize_words(text_raw)
 
 
 def test_normal_entries_top_pages(index, data, mocker):
@@ -117,3 +125,24 @@ def test_redirects_with_special_chars(index, data, mocker, title):
     assert index.create.call_count == 1
     entries = list(index.create.call_args[0][1])
     assert len(entries) == 2
+
+
+@pytest.mark.parametrize('title, expected_tokens', (
+    ('Foo BAR', {'foo', 'bar'}),
+    ('José de San Martín', {'jose', 'de', 'san', 'martin'}),
+    ('Jeep Ñandú', {'jeep', 'nandu'}),
+    ('Grañón (La Rioja)', {'granon', 'la', 'rioja'}),
+    ('Chacarita (Buenos Aires)', {'chacarita', 'buenos', 'aires'}),
+    ('Número π', {'numero', 'π'}),
+    ('AC/DC', {'ac/dc', 'ac', 'dc'}),
+    ('.com', {'.com', 'com'}),
+    ('$9.99', {'$9.99', '99', '9'}),
+    ('Fahrenheit 9/11', {'fahrenheit', '9/11', '9', '11'}),
+    ('♥ Heart (álbum)', {'♥', 'heart', 'album'}),
+    ('Србија', {'србија'}),
+    ('Έλενα Παπαρίζου', {'ελενα', 'παπαριζου'}),
+))
+def test_title_tokenization(title, expected_tokens):
+    """Check the tokens that will be inserted in the index."""
+    tokens = set(cdpindex.tokenize_title(title))
+    assert tokens == expected_tokens


### PR DESCRIPTION
### Incluir tokens con símbolos

Agregada la función `tokenize_title` para una mejor extración de tokens.

| Título | Tokens antes  | Tokens ahora |
| ------------- | ------------- | ------------- |
| `AC/DC` | `ac`, `dc` | `ac`, `dc`, `ac/cd` |
| `.com` | `com` | `com`, `.com` |
| `Fahrenheit 9/11` | `Fahrenheit`, `9`, `11` | `fahrenheit`, `9/11`, `9`, `11`, |

Estas nuevas entradas se agregan al índice, permitiendo obtener los resultados esperados cuando se busca `.com` o `AC/DC` (fix #326).


### Mejorar el comportamiento de la función `normalize_words`:

- convertir a minúsculas
- eliminar diacríticos
- mantener caracteres no ASCII para soportar títulos en alfabetos no latinos

Comportamiento con los cambios:

| Raw | Normalized |
| --- | ---------- |
| `FOO` | `foo` |
| `FóÕ` | `foo` |
| `ñandú` | `nandu` |
| `.com` | `.com` |
| `AC/DC` | `ac/dc` |
| `Србија` | `србија` | 
| `замо́к` | `замок` |
| `παϊδάκια` | `παιδακια` |


Con estos cambios, la tokenización funciona correctamente para caracteres no ASCII (fix #346)

| Título | tokens |
| ------------- | ------------- |
| `Jeep Ñandú` | `jeep`, `nandu` | 
| `Número π` | `numero`, `π` |
| `Έλενα Παπαρίζου` | `ελενα`, `παπαριζου` |
| `♥ Heart (álbum)` | `♥`, `heart`, `album` |

Ahora por ej. si el artículo `Número π` está incluído y se busca `π`, se obtiene:

<kbd><img src="https://user-images.githubusercontent.com/61316398/102707263-2dfd0f00-4278-11eb-8af8-6ea5d9f3348b.png" width="500px"></kbd>



### Tests

- más casos de prueba para `test_word_normalization`
- agregado `test_title_tokenization` para verificar la tokenización que queremos lograr
