### PR TITLE
Reorder results in the index search.

### DIFF
--- a/src/armado/sqlite_index.py
+++ b/src/armado/sqlite_index.py
@@ -17,6 +17,7 @@
 
 import array
 import logging
+import math
 import operator
 import os
 import pickle
@@ -32,7 +33,7 @@ from src.armado import to3dirs
 logger = logging.getLogger(__name__)
 
 PAGE_SIZE = 512
-MAX_RESULTS = 500
+MAX_RESULTS = 50
 
 
 def normalize_words(txt):
@@ -202,9 +203,12 @@ class Search:
                 phrase[pos] = word
             difference = self.iterative_levenshtein(phrase)
 
-            self.ordered.append((difference, docid))
+            # first docid are a LOT more important
+            order_factor = int(40000 * math.pow(docid + 1, -.5))
 
-        self.ordered.sort()
+            self.ordered.append((order_factor - difference, docid))
+
+        self.ordered.sort(reverse=True)
 
     @lru_cache(1000)
     def _get_page(self, pageid):

--- a/utilities/search_index.py
+++ b/utilities/search_index.py
@@ -22,8 +22,11 @@ import timeit
 sys.path.append(os.path.abspath(os.curdir))
 
 from src.armado.sqlite_index import Index # NOQA import after fixing path
+from src.armado import to3dirs
 
 PAGE = 50
+
+to3dirs.namespaces.load("/home/facundo/temp/cdpdump/es/resources")
 
 
 def output(*out):


### PR DESCRIPTION
This keeps the 2-steps ordering of the results, but simplified the first case, and using more elements in the second case.

The first step is to order ALL results according to the similitude, like it was being done, but NOT using the docid position (it's irrelevant now because of the changes in the second step). Note that this first step is super important, as the second step will stop decompressing results once the limit is achieved, so it's critical to have the more simile first.

The second step collects the results *per html*, keeping only the result with greater "page score" for that HTML (but giving priority when the article is original, as it has the same score than the redirects). After getting to the result limit, all the results are returned using the original page score.