### PR TITLE
Mejoras en el envío de redirects al índice

### DIFF
--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -31,9 +31,6 @@ from .sqlite_index import Index, normalize_words
 
 logger = logging.getLogger(__name__)
 
-# regex used to separate words
-WORDS = re.compile(r"\w+", re.UNICODE)
-
 
 class IndexInterface(threading.Thread):
     """Process the information needed to connect with index.

--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -140,28 +140,22 @@ def generate_from_html(dirbase, verbose):
             ptje = 50 + score // 1000
             data = (namhtml, title, ptje, True, primtext)
             check_already_seen(data)
-            words = tokenize(title)
-            yield tuple(words), ptje, data
+            orig_words = tuple(tokenize(title))
+            yield orig_words, ptje, data
 
             # pass words to the redirects which points to
             # this html file, using the same score
             arch_orig = urllib.parse.unquote(arch)  # special filesystem chars
             if arch_orig in redirs:
-                # keep sets of already indexed words, to ignore exact-words redirects
-                already_indexed_words = {tuple(words)}
-
-                for words in redirs[arch_orig]:
-                    if words in already_indexed_words:
-                        # all about this redirect was included before, ignore
-                        continue
-                    already_indexed_words.add(words)
-
+                # get redirect words (excluding the ones already used in the original article)
+                all_redir_words = redirs[arch_orig] - {orig_words}
+                for redir_words in all_redir_words:
                     # the title is missing in the original article so we use the words found in
                     # the filename (it isn't the optimal solution, but works)
-                    title = " ".join(words)
+                    title = " ".join(redir_words)
                     data = (namhtml, title, ptje, False, "")
                     check_already_seen(data)
-                    yield words, ptje, data
+                    yield redir_words, ptje, data
 
     # ensures an empty directory
     if os.path.exists(config.DIR_INDICE):

--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -89,10 +89,8 @@ def filename2words(fname):
     """Transforms a filename in the title and words."""
     if fname.endswith(".html"):
         fname = fname[:-5]
-    x = normalize_words(fname)
-    p = x.split("_")
-    t = " ".join(p)
-    return p, t
+    normalized = normalize_words(fname)
+    return re.split("[_ ]", normalized)
 
 
 def tokenize_title(title):
@@ -114,12 +112,8 @@ def generate_from_html(dirbase, verbose):
     redirs = defaultdict(set)
     for line in open(config.LOG_REDIRECTS, "rt", encoding="utf-8"):
         orig, dest = line.strip().split(config.SEPARADOR_COLUMNAS)
-
-        # in the original article, the title is missing
-        # so we use the words founded in the filename
-        # it isn't the optimal solution, but works
-        words, title = filename2words(orig)
-        redirs[dest].add((tuple(words), title))
+        words = filename2words(orig)
+        redirs[dest].add(tuple(words))
 
     top_pages = preprocess.pages_selector.top_pages
 
@@ -156,10 +150,22 @@ def generate_from_html(dirbase, verbose):
             # this html file, using the same score
             arch_orig = urllib.parse.unquote(arch)  # special filesystem chars
             if arch_orig in redirs:
-                for (words, title) in redirs[arch_orig]:
+                already_used_words = words.copy()  # leave the original intact
+                for words in redirs[arch_orig]:
+                    # store the redirect for the words that are not also pointing to the
+                    # original article
+                    redir_only_words = set(words) - already_used_words
+                    if not redir_only_words:
+                        # all about this redirect was included before, ignore
+                        continue
+
+                    # the title is missing in the original article so we use the words found in
+                    # the filename (it isn't the optimal solution, but works)
+                    title = " ".join(words)
                     data = (namhtml, title, ptje, False, "")
                     check_already_seen(data)
-                    yield list(words), ptje, data
+                    yield redir_only_words, ptje, data
+                    already_used_words.update(redir_only_words)
 
     # ensures an empty directory
     if os.path.exists(config.DIR_INDICE):

--- a/tests/test_cdpindex.py
+++ b/tests/test_cdpindex.py
@@ -119,15 +119,19 @@ def test_repeated_entry_redirects(index, data, mocker):
     assert index.create.call_count == 1
     entries = list(index.create.call_args[0][1])
 
-    # should have one entry from top_pages and one entry from redirects; both kind of entries
-    # have the same normalized title, url and score but differs in a boolean param.
+    # should have one entry from top_pages and one entry from redirects:
+    #  - YES: the original article, for sure
+    #  - NO: both next redirects, which after normalization have the same words
+    #  - YES: the redirect bringing new words (note ALL words are indexed, not only the different
+    #         ones, as all are needed if the user search for those words doing an AND)
+    #  - NO: the last redirect, that again are the same words than an already indexed item
     assert len(entries) == 2
     words, _, (html, _, _, is_original, _) = entries[0]
     assert words == {'bar', 'foo'}
     assert html == 'f/o/o_bar/foo_bar'
     assert is_original
     words, _, (html, _, _, is_original, _) = entries[1]
-    assert words == {'bazzz'}
+    assert words == {'foo', 'bazzz'}
     assert html == 'f/o/o_bar/foo_bar'
     assert not is_original
 

--- a/tests/test_cdpindex.py
+++ b/tests/test_cdpindex.py
@@ -60,16 +60,6 @@ def test_word_normalization(text_raw, text_norm):
     assert text_norm == cdpindex.normalize_words(text_raw)
 
 
-@pytest.mark.parametrize('fname_raw, words', (
-    ('España´82', ['espana', '82']),
-    ('España 82', ['espana', '82']),
-    ('España_82', ['espana', '82']),
-))
-def test_filename_to_words(fname_raw, words):
-    """Check getting words from the filename (used for redirects)."""
-    assert cdpindex.filename2words(fname_raw) == words
-
-
 def test_normal_entries_top_pages(index, data, mocker):
     """All entries from top_pages should be added to the index."""
     top_pages = [
@@ -114,45 +104,34 @@ def test_repeated_entry_redirects(index, data, mocker):
         fh.write('Foo Bar|foo_bar\n')
         fh.write('FOO BAR|foo_bar\n')
         fh.write('fOO bazzz|foo_bar\n')
+        fh.write('fOO BAZZZ|foo_bar\n')
         fh.write('BAZZZ fOo|foo_bar\n')
+        fh.write('bazzz_fOo|foo_bar\n')
     cdpindex.generate_from_html(None, None)
     assert index.create.call_count == 1
     entries = list(index.create.call_args[0][1])
 
-    # should have one entry from top_pages and one entry from redirects:
+    # should have one entry from top_pages and two entry from redirects:
     #  - YES: the original article, for sure
     #  - NO: both next redirects, which after normalization have the same words
     #  - YES: the redirect bringing new words (note ALL words are indexed, not only the different
     #         ones, as all are needed if the user search for those words doing an AND)
-    #  - NO: the last redirect, that again are the same words than an already indexed item
-    assert len(entries) == 2
+    #  - YES: the next redirect, that even having same words, they are in different order (the
+    #         score of the selected results are order dependant!)
+    #  - NO: the last redirect, again having "same words same order" of other one already included
+    assert len(entries) == 3
+
+    # the first one for sure must be the original
     words, _, (html, _, _, is_original, _) = entries[0]
-    assert words == {'bar', 'foo'}
+    assert words == ('foo', 'bar')
     assert html == 'f/o/o_bar/foo_bar'
     assert is_original
-    words, _, (html, _, _, is_original, _) = entries[1]
-    assert words == {'foo', 'bazzz'}
-    assert html == 'f/o/o_bar/foo_bar'
-    assert not is_original
 
-
-def test_repeated_entry_redirects_special_madres(index, data, mocker):
-    """Specific test for madres."""
-    with open(config.LOG_TITLES, 'wt', encoding='utf-8') as fh:
-        fh.write('Madres_de_Plaza_de_Mayo|Madres de Plaza de Mayo|\n')
-    top_pages = [('M/a/dres_de_Plaza_de_Mayo', 'Madres_de_Plaza_de_Mayo', 10)]
-    mocker.patch('src.preprocessing.preprocess.pages_selector', mocker.Mock(top_pages=top_pages))
-
-    # these redirects will have similar titles after normalization, those will exact words
-    # will be not included, only the one with the new word (and NOT the repeated one after that!)
-    with open(config.LOG_REDIRECTS, 'wt', encoding='utf-8') as fh:
-        fh.write('Madres|Madres_de_Plaza_de_Mayo\n')
-    cdpindex.generate_from_html(None, None)
-    assert index.create.call_count == 1
-    entries = list(index.create.call_args[0][1])
-    assert len(entries) == 2
-    assert entries[0][0] == {'madres', 'de', 'plaza', 'mayo'}
-    assert entries[1][0] == {'madres'}
+    # the rest must be redirects, point to same html, and with specific words
+    # (comparing like this because order may change)
+    assert {e[2][3] for e in entries[1:]} == {False}
+    assert {e[2][0] for e in entries[1:]} == {'f/o/o_bar/foo_bar'}
+    assert {e[0] for e in entries[1:]} == {('foo', 'bazzz'), ('bazzz', 'foo')}
 
 
 @pytest.mark.parametrize('title', ('foo/bar', 'foo.bar', 'foo%bar'))
@@ -174,21 +153,24 @@ def test_redirects_with_special_chars(index, data, mocker, title):
 
 
 @pytest.mark.parametrize('title, expected_tokens', (
-    ('Foo BAR', {'foo', 'bar'}),
-    ('José de San Martín', {'jose', 'de', 'san', 'martin'}),
-    ('Jeep Ñandú', {'jeep', 'nandu'}),
-    ('Grañón (La Rioja)', {'granon', 'la', 'rioja'}),
-    ('Chacarita (Buenos Aires)', {'chacarita', 'buenos', 'aires'}),
-    ('Número π', {'numero', 'π'}),
-    ('AC/DC', {'ac/dc', 'ac', 'dc'}),
-    ('.com', {'.com', 'com'}),
-    ('$9.99', {'$9.99', '99', '9'}),
-    ('Fahrenheit 9/11', {'fahrenheit', '9/11', '9', '11'}),
-    ('♥ Heart (álbum)', {'♥', 'heart', 'album'}),
-    ('Србија', {'србија'}),
-    ('Έλενα Παπαρίζου', {'ελενα', 'παπαριζου'}),
+    ('Foo BAR', ['foo', 'bar']),
+    ('José de San Martín', ['jose', 'de', 'san', 'martin']),
+    ('Jeep Ñandú', ['jeep', 'nandu']),
+    ('Grañón (La Rioja)', ['granon', 'la', 'rioja']),
+    ('Chacarita (Buenos Aires)', ['chacarita', 'buenos', 'aires']),
+    ('Número π', ['numero', 'π']),
+    ('AC/DC', ['ac/dc']),
+    ('.com', ['.com']),
+    ('$9.99', ['$9.99']),
+    ('Fahrenheit 9/11', ['fahrenheit', '9/11']),
+    ('♥ Heart (álbum)', ['♥', 'heart', 'album']),
+    ('Србија', ['србија']),
+    ('Έλενα Παπαρίζου', ['ελενα', 'παπαριζου']),
+    ('España´82', ['espana', '82']),
+    ('España 82', ['espana', '82']),
+    ('España_82', ['espana', '82']),
 ))
 def test_title_tokenization(title, expected_tokens):
     """Check the tokens that will be inserted in the index."""
-    tokens = set(cdpindex.tokenize_title(title))
+    tokens = cdpindex.tokenize(title)
     assert tokens == expected_tokens


### PR DESCRIPTION
Incluyendo:

- filename2words ahora separa tanto por '_' como por ' '; esto es algo que nos mordió en la creación del beta, que generaba los "títulos repetidos".

- filename2words ahora sólo devuelve `words` (antes también devolvía esas words unidas por espacio); entonces `redirs` sólo almacena esas `words`, y se termina armando el título después (a menos que el redirect sea ignorado, por tener sólo palabras repetidas); esto ahorra memoria seguro, y potencialmente procesamiento.

- ahora no mandamos TODOS los redirects al índice usando TODAS sus palabras, sólo lo que no se usó antes.

Un ejemplo de esto último, indicando qué palabras y título tiene el original, y un par de redirects, y mostrando con qué palabras se encontraría (el título queda tal cual!!!); tener en cuenta que el orden es importante, el original va primero y luego los redirects:

| tipo | words | title | -> | words indizadas |
| ---- | ----- | ----- | -- | -------------   |
| original | `['domingo', 'faustino', 'sarmiento']` | Domingo Faustino Sarmiento | -> | `['domingo', 'faustino', 'sarmiento']` |
| redirect | `['domingo', 'escuelita', 'sarmiento']` | Domingo Escuelita Sarmiento | -> | `['escuelita']` |
| redirect | `['domingo', 'sarmiento']` | Domingo Sarmiento | -> | IGNORADO |
| redirect | `['escuelita', 'sarmiento']` | Escuelita Sarmiento | -> | IGNORADO |
| redirect | `['sarmiento', 'faustino']` | Sarmiento, Faustino | -> | IGNORADO |

Los IGNORADO son redirects que NO se terminan indizando, porque si se busca por cualquiera de sus palabras se terminaría encontrando el original o cualquiera de los redirects anteriores.