### PR TITLE
Show redirects with the information extracted from primary entry

### DIFF
--- a/src/armado/cdpindex.py
+++ b/src/armado/cdpindex.py
@@ -119,7 +119,7 @@ def generate_from_html(dirbase, verbose):
         # so we use the words founded in the filename
         # it isn't the optimal solution, but works
         words, title = filename2words(orig)
-        redirs[dest].add((tuple(words), title))
+        redirs[dest].add(tuple(words))
 
     top_pages = preprocess.pages_selector.top_pages
 
@@ -150,16 +150,11 @@ def generate_from_html(dirbase, verbose):
             data = (namhtml, title, ptje, True, primtext)
             check_already_seen(data)
             words = tokenize_title(title)
-            yield words, ptje, data
 
             # pass words to the redirects which points to
             # this html file, using the same score
             arch_orig = urllib.parse.unquote(arch)  # special filesystem chars
-            if arch_orig in redirs:
-                for (words, title) in redirs[arch_orig]:
-                    data = (namhtml, title, ptje, False, "")
-                    check_already_seen(data)
-                    yield list(words), ptje, data
+            yield words, ptje, data, redirs[arch_orig]
 
     # ensures an empty directory
     if os.path.exists(config.DIR_INDICE):

--- a/src/armado/easy_index.py
+++ b/src/armado/easy_index.py
@@ -185,7 +185,7 @@ class Index(object):
         indexed_counter = 0
 
         # fill them
-        for keys, ptje, data in source:
+        for keys, ptje, data, redirs in source:
             checkme = all([isinstance(keys, list),
                           isinstance(ptje, int),
                           isinstance(data, tuple)])
@@ -197,7 +197,6 @@ class Index(object):
                 raise ValueError("Keys cannot contain newlines")
             indexed_counter += len(keys)
             value = list(data)
-
             # docid -> info final
             # don't add to tmp_reverse_id or ids_shelf if the value is repeated
             docid = ids_cnter
@@ -208,6 +207,16 @@ class Index(object):
             # keys -> docid
             for key in keys:
                 key_shelf.setdefault(key, set()).add(docid)
+
+            # create the additional entries for redirs
+            for redir in redirs:
+                redir_data = (data[0], ' '.join(redir), data[2], False, '')
+                redir_docid = ids_cnter
+                ids_cnter += 1
+                ids_shelf[redir_docid] = redir_data
+
+                for key in redir:
+                    key_shelf.setdefault(key, set()).add(redir_docid)
 
         if ids_cnter == 0:
             raise ValueError("No data to index")

--- a/src/armado/sqlite_index.py
+++ b/src/armado/sqlite_index.py
@@ -526,7 +526,7 @@ class Index:
                 for idx, word in enumerate(words):
                     idx_dict[word].append(prim_docid, idx)
                 for redir in redirs:
-                    redir_data = (prim_docid, ' '.join(words))
+                    redir_data = (prim_docid, ' '.join(redir))
                     docid = docs_table.append((len(redir), redir_data))
                     for idx, word in enumerate(redir):
                         idx_dict[word].append(docid, idx)

--- a/tests/test_cdpindex.py
+++ b/tests/test_cdpindex.py
@@ -106,7 +106,8 @@ def test_repeated_entry_redirects(index, data, mocker):
     entries = list(index.create.call_args[0][1])
     # should have one entry from top_pages and one entry from redirects; both kind of entries
     # have the same normalized title, url and score but differs in a boolean param.
-    assert len(entries) == 2
+    # the primary entry is sended with the redirs added
+    assert len(entries) == 1
 
 
 @pytest.mark.parametrize('title', ('foo/bar', 'foo.bar', 'foo%bar'))
@@ -124,7 +125,8 @@ def test_redirects_with_special_chars(index, data, mocker, title):
     cdpindex.generate_from_html(None, None)
     assert index.create.call_count == 1
     entries = list(index.create.call_args[0][1])
-    assert len(entries) == 2
+    # the primary entry is sended with the redirs added
+    assert len(entries) == 1
 
 
 @pytest.mark.parametrize('title, expected_tokens', (

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -49,7 +49,8 @@ class DataSet:
     def add_fixture(cls, key, data):
         docs = [n.strip().split("/") for n in data.split(";")]
         docs = [(n[0], int(n[1])) for n in docs]
-        info = [(n[0].lower().split(" "), n[1], (None, n[0])) for n in docs]
+        redirs = []
+        info = [(n[0].lower().split(" "), n[1], (None, n[0]), redirs) for n in docs]
         cls.fixtures[key] = info
 
     def __init__(self, key):
@@ -68,7 +69,7 @@ class DataSet:
 
 def test_auxiliary():
     DataSet.add_fixture("one", "ala blanca/3")
-    assert DataSet("one").info == [(['ala', 'blanca'], 3, (None, 'ala blanca'))]
+    assert DataSet("one").info == [(['ala', 'blanca'], 3, (None, 'ala blanca'), [])]
     r = [("A/l/a/Ala_Blanca", "ala blanca", ),
          ("A/l/a/Ala", "ala", )]
     s = "ala blanca; ala"

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -62,8 +62,8 @@ def create_app_client(mocker, tmp_path):
 
     # a bogus index with a couple of items (so it behaves properly for get_random and similar)
     mocker.patch('config.DIR_INDICE', str(tmp_path))
-    fake_content = [(['key1'], 7, ('p/a/g/page1', 'Page1')),
-                    (['key2'], 8, ('p/a/g/page2', 'Page2'))]
+    fake_content = [(['key1'], 7, ('p/a/g/page1', 'Page1'), []),
+                    (['key2'], 8, ('p/a/g/page2', 'Page2'), [])]
     cdpindex.Index.create(str(tmp_path), fake_content)
 
     app = web_app.create_app(watchdog=None, with_static=False)


### PR DESCRIPTION
Put redirects inside index as pointers to primary entry.
To ensure correct linking, redirs are sended to create index just as a new argument.
This is a list of lists, and includes the words in the redirect's title.
