### PR TITLE
[hotfix] Fix scraper.py regex

### DIFF
--- a/src/scraping/scraper.py
+++ b/src/scraping/scraper.py
@@ -316,8 +316,8 @@ class CSSLinkExtractor:
 css_link_extractor = CSSLinkExtractor()
 
 regex = (
-    r'(<h1 id="firstHeading" class="firstHeading" '
-    r'lang=".+">.+</h1>)(.+)\s*<div class="printfooter">')
+    r'(<h1 id="firstHeading" class="firstHeading" >.+</h1>)'
+    r'(.+)\s*<div class="printfooter">')
 capture = re.compile(regex, re.MULTILINE | re.DOTALL).search
 
 


### PR DESCRIPTION
It seems that the format of the `<h1>` tags that we take to extract a part of the html changed