### PR TITLE
Improve image processing logs

### DIFF
--- a/src/images/calculate.py
+++ b/src/images/calculate.py
@@ -52,11 +52,12 @@ class Scaler:
                     add_images, self.total_items, vals_tplt)
 
     def get_items(self):
-        limit = 0
+        """Give image index to incorporate and its theoretical resizing."""
+        idx = 0
         for quant, scale in self.scale_vals:
             for _ in range(quant):
-                yield (limit, scale)
-                limit += 1
+                yield (idx, scale)
+                idx += 1
 
 
 def image_is_required(url):

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -121,8 +121,16 @@ def run(verbose, src):
 
     resize = done_now.values()
     rescale = {str(k): v for k, v in Counter(resize).items()}
-    logger.info("Resize done! | Final scales: %(100)s at 100%% - %(75)s at 75%% - %(50)s at 50%%",
+    logger.info("Resize done! | Final scales: %(100)i at 100%% - %(75)i at 75%% - %(50)i at 50%%",
                 rescale)
+    # extract extensions
+    exts = [os.path.splitext(x)[1].lower().replace('.jpeg', '.jpg') for x in done_now]
+    # exts logging
+    exts_template = 'Formats and quantities -> '
+    exts_template += ' - '.join(': '.join((ext[1:], str(items)))
+                                for ext, items in Counter(exts).items())
+    logger.info(exts_template)
+
     # save images processed now
     with open(config.LOG_REDUCDONE, "wt", encoding="utf-8") as fh:
         for dskurl, scale in done_now.items():

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -120,13 +120,13 @@ def run(verbose, src):
                     logger.exception("Error processing %s", frompath)
 
     resize = done_now.values()
-    rescale = {str(k): v for k, v in Counter(resize).items()}
-    logger.info("Resize done! | Final scales: %(100)i at 100%% - %(75)i at 75%% - %(50)i at 50%%",
-                rescale)
+    rescale_tplt = ' - '.join('{} at {}%'.format(quant, scale)
+                              for scale, quant in sorted(Counter(resize).items(), reverse=True))
+    logger.info("Resize done! | Final scales: %s", rescale_tplt)
     # extract extensions
     exts = [os.path.splitext(x)[1].lower().replace('.jpeg', '.jpg') for x in done_now]
     # exts logging
-    exts_template = ' '.join('='.join((ext[1:], str(items)))
+    exts_template = ' '.join('{}={}'.format(ext[1:], items)
                              for ext, items in Counter(exts).items())
     logger.info('Formats and quantities: %s', exts_template)
 

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -126,10 +126,9 @@ def run(verbose, src):
     # extract extensions
     exts = [os.path.splitext(x)[1].lower().replace('.jpeg', '.jpg') for x in done_now]
     # exts logging
-    exts_template = 'Formats and quantities -> '
-    exts_template += ' - '.join(': '.join((ext[1:], str(items)))
-                                for ext, items in Counter(exts).items())
-    logger.info(exts_template)
+    exts_template = ' '.join('='.join((ext[1:], str(items)))
+                             for ext, items in Counter(exts).items())
+    logger.info('Formats and quantities: %s', exts_template)
 
     # save images processed now
     with open(config.LOG_REDUCDONE, "wt", encoding="utf-8") as fh:

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -20,6 +20,7 @@ import config
 import logging
 import os
 import shutil
+from collections import Counter
 
 from PIL import Image
 
@@ -118,6 +119,10 @@ def run(verbose, src):
                 except Exception:
                     logger.exception("Error processing %s", frompath)
 
+    resize = done_now.values()
+    rescale = {str(k): v for k, v in Counter(resize).items()}
+    logger.info("Resize done! | Final scales: %(100)s at 100%% - %(75)s at 75%% - %(50)s at 50%%",
+                rescale)
     # save images processed now
     with open(config.LOG_REDUCDONE, "wt", encoding="utf-8") as fh:
         for dskurl, scale in done_now.items():

--- a/tests/test_images_calculate.py
+++ b/tests/test_images_calculate.py
@@ -70,7 +70,7 @@ def test_scaler(image_config):
     p = config.imageconf['image_reduction']
     expect = [x for i in range(len(s)) for x in [s[i]] * p[i]]
     scaler = calculate.Scaler(images)
-    result = [scaler() for i in range(scaler.total_items)]
+    result = [scale for _, scale in scaler.get_items()]
     assert expect == result
 
 

--- a/tests/test_images_calculate.py
+++ b/tests/test_images_calculate.py
@@ -70,7 +70,7 @@ def test_scaler(image_config):
     p = config.imageconf['image_reduction']
     expect = [x for i in range(len(s)) for x in [s[i]] * p[i]]
     scaler = calculate.Scaler(images)
-    result = [scaler(i) for i in range(images)]
+    result = [scaler() for i in range(scaler.total_items)]
     assert expect == result
 
 
@@ -89,7 +89,7 @@ def test_is_not_required(image_url, expected_result):
 
 @pytest.mark.parametrize('reduction', (
     (0, 0, 0, 100),
-    (10, 20, 30, 50),
+    (10, 10, 30, 50),
     (20, 30, 50, 0),
     (100, 0, 0, 0),
 ))
@@ -129,7 +129,7 @@ def test_no_images(mocker, image_data):
 def test_no_repeated_images(mocker, image_data):
     """Image with same name should be included only once."""
     mocker.patch('config.IMAGES_REQUIRED', True)
-    mocker.patch('config.imageconf', {'image_reduction': [30, 30, 40, 0]})
+    mocker.patch('config.imageconf', {'image_reduction': [100, 0, 0, 0]})
     calculate.run()
     with open(config.LOG_REDUCCION, 'rt', encoding='utf-8') as fh:
         images = fh.read()


### PR DESCRIPTION
Some changes in logs:

```python3
2021-03-12 19:58:18,355  generar              INFO     Extracted 0 images, need to download 8008
2021-03-12 19:58:18,355  generar              INFO     Recalculating the reduction percentages.
2021-03-12 19:58:18,411  images.calculate     INFO     Add images: 20% - 1581 total | Scales: 395 at 100% - 395 at 75% - 791 at 50%
2021-03-12 19:58:18,414  images.calculate     INFO     Add 89 at 100% SVG images required - Total images to add: 1670
2021-03-12 19:58:18,416  generar              INFO     Downloading the images from the internet
2021-03-12 20:05:31,286  src.utiles           INFO     Scraping done! Total=1670  ok=1670  bad=0
2021-03-12 20:05:31,289  generar              INFO     Reducing the downloaded images
2021-03-12 20:05:32,073  images.scale         INFO     Resize done! | Final scales: 990 at 100% - 259 at 75% - 421 at 50%
2021-03-12 20:05:32,074  generar              INFO     Embedding selected images
2021-03-12 20:05:32,860  generar              INFO     Putting the reduced images into blocks
2021-03-12 20:05:33,078  generar              INFO     Got 8 blocks with 1581 images
2021-03-12 20:05:33,078  generar              INFO     Generating the index

```