### PR TITLE
Cambia el hardcoded en la URL de la extraccion de la imagen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ temp/
 cdpedia-es*
 cdpetron.log
 scraper.log
+venv
 .idea

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -216,7 +216,7 @@ class ImageParser:
         elif img_src.startswith("//bits.wikimedia.org/"):
             dsk_url = img_src[46:]
 
-        elif img_src.startswith(f"//upload.wikimedia.org/wikipedia/{config.LANGUAGE}/"):
+        elif img_src.startswith("//upload.wikimedia.org/wikipedia/%s/" % config.LANGUAGE):
             dsk_url = img_src[36:]
 
         elif img_src.startswith("//upload.wikimedia.org/"):

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -38,7 +38,6 @@ from src.preprocessing import preprocess
 
 IMG_URL_PREFIX = config.IMAGES_URL_PREFIX
 
-
 WIKIPEDIA_URL = "https://%s.wikipedia.org" % config.LANGUAGE
 
 MEDIAWIKI_URL_PREFIX_LANG = "//upload.wikimedia.org/wikipedia/%s/" % config.LANGUAGE
@@ -220,7 +219,6 @@ class ImageParser:
             dsk_url = img_src[46:]
 
         elif img_src.startswith(MEDIAWIKI_URL_PREFIX_LANG):
-            print(MEDIAWIKI_URL_PREFIX_LANG)
             dsk_url = img_src[len(MEDIAWIKI_URL_PREFIX_LANG):]
 
         elif img_src.startswith("//upload.wikimedia.org/"):

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -38,9 +38,9 @@ from src.preprocessing import preprocess
 
 IMG_URL_PREFIX = config.IMAGES_URL_PREFIX
 
-WIKIPEDIA_URL = "https://%s.wikipedia.org" % config.LANGUAGE
+WIKIPEDIA_URL = "https://{}.wikipedia.org".format(config.LANGUAGE)
 
-MEDIAWIKI_URL_PREFIX_LANG = "//upload.wikimedia.org/wikipedia/%s/" % config.LANGUAGE
+MEDIAWIKI_URL_PREFIX_LANG = "//upload.wikimedia.org/wikipedia/{}/".format(config.LANGUAGE)
 
 # we plainly don't want some images
 IMAGES_TO_REMOVE = [

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -38,7 +38,10 @@ from src.preprocessing import preprocess
 
 IMG_URL_PREFIX = config.IMAGES_URL_PREFIX
 
-WIKIPEDIA_URL = "https://{}.wikipedia.org".format(config.LANGUAGE)
+
+WIKIPEDIA_URL = "https://%s.wikipedia.org" % config.LANGUAGE
+
+MEDIAWIKI_URL_PREFIX_LANG = "//upload.wikimedia.org/wikipedia/%s/" % config.LANGUAGE
 
 # we plainly don't want some images
 IMAGES_TO_REMOVE = [
@@ -216,8 +219,9 @@ class ImageParser:
         elif img_src.startswith("//bits.wikimedia.org/"):
             dsk_url = img_src[46:]
 
-        elif img_src.startswith("//upload.wikimedia.org/wikipedia/%s/" % config.LANGUAGE):
-            dsk_url = img_src[36:]
+        elif img_src.startswith(MEDIAWIKI_URL_PREFIX_LANG):
+            print(MEDIAWIKI_URL_PREFIX_LANG)
+            dsk_url = img_src[len(MEDIAWIKI_URL_PREFIX_LANG):]
 
         elif img_src.startswith("//upload.wikimedia.org/"):
             dsk_url = img_src[23:]

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -216,7 +216,7 @@ class ImageParser:
         elif img_src.startswith("//bits.wikimedia.org/"):
             dsk_url = img_src[46:]
 
-        elif img_src.startswith("//upload.wikimedia.org/wikipedia/es/"):
+        elif img_src.startswith(f"//upload.wikimedia.org/wikipedia/{config.LANGUAGE}/"):
             dsk_url = img_src[36:]
 
         elif img_src.startswith("//upload.wikimedia.org/"):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -86,27 +86,29 @@ class ReplaceImageParserTestCase(unittest.TestCase):
         should_dsk = "magnify-clip.png"
         self._check(url, should_web, should_dsk)
 
-    @unittest.mock.patch('config.LANGUAGE', 'es')
+    @unittest.mock.patch('src.images.extract.MEDIAWIKI_URL_PREFIX_LANG',
+                         '//upload.wikimedia.org/wikipedia/zh-min-nan/')
     def test_replace_timeline(self):
         url = (
-            "//upload.wikimedia.org/wikipedia/es/"
+            "//upload.wikimedia.org/wikipedia/zh-min-nan/"
             "timeline/cc707d3b957628b5e432d7242096abc5.png"
         )
         should_web = (
-            "http://upload.wikimedia.org/wikipedia/es/"
+            "http://upload.wikimedia.org/wikipedia/zh-min-nan/"
             "timeline/cc707d3b957628b5e432d7242096abc5.png"
         )
         should_dsk = "timeline/cc707d3b957628b5e432d7242096abc5.png"
         self._check(url, should_web, should_dsk)
 
-    @unittest.mock.patch('config.LANGUAGE', 'pt')
+    @unittest.mock.patch('src.images.extract.MEDIAWIKI_URL_PREFIX_LANG',
+                         '//upload.wikimedia.org/wikipedia/es/')
     def test_replace_math(self):
         url = (
-            "//upload.wikimedia.org/wikipedia/pt/"
+            "//upload.wikimedia.org/wikipedia/es/"
             "math/6/7/e/67ed4566dba0caae24ec4cf25133f200.png"
         )
         should_web = (
-            "http://upload.wikimedia.org/wikipedia/pt/"
+            "http://upload.wikimedia.org/wikipedia/es/"
             "math/6/7/e/67ed4566dba0caae24ec4cf25133f200.png"
         )
         should_dsk = "math/6/7/e/67ed4566dba0caae24ec4cf25133f200.png"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -86,6 +86,7 @@ class ReplaceImageParserTestCase(unittest.TestCase):
         should_dsk = "magnify-clip.png"
         self._check(url, should_web, should_dsk)
 
+    @unittest.mock.patch('config.LANGUAGE', 'es')
     def test_replace_timeline(self):
         url = (
             "//upload.wikimedia.org/wikipedia/es/"
@@ -98,13 +99,14 @@ class ReplaceImageParserTestCase(unittest.TestCase):
         should_dsk = "timeline/cc707d3b957628b5e432d7242096abc5.png"
         self._check(url, should_web, should_dsk)
 
+    @unittest.mock.patch('config.LANGUAGE', 'pt')
     def test_replace_math(self):
         url = (
-            "//upload.wikimedia.org/wikipedia/es/"
+            "//upload.wikimedia.org/wikipedia/pt/"
             "math/6/7/e/67ed4566dba0caae24ec4cf25133f200.png"
         )
         should_web = (
-            "http://upload.wikimedia.org/wikipedia/es/"
+            "http://upload.wikimedia.org/wikipedia/pt/"
             "math/6/7/e/67ed4566dba0caae24ec4cf25133f200.png"
         )
         should_dsk = "math/6/7/e/67ed4566dba0caae24ec4cf25133f200.png"


### PR DESCRIPTION
Resolve:  #357  

This PR adds:
- Extract the image using the `config.LANGUAGE` variable so removed the hardcoded language 
- Update the test functions for the extraction image code.
- Update the `.gitignore` file excluding the `venv`