### PR TITLE
Frapell enhancements

### DIFF
--- a/config.py
+++ b/config.py
@@ -123,6 +123,9 @@ LOG_REDUCDONE = DIR_TEMP + "/reduc_done.txt"
 LOG_TITLES = DIR_TEMP + "/titles.txt"
 LOG_LOCALE = DIR_TEMP + "/locale.txt"
 
+# Maximum filename length
+IMG_MAX_NAME_LEN = 240
+
 # prefix for URL of local images
 IMAGES_URL_PREFIX = "/images/"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ progress
 pytest
 pytest-mock
 lxml
+python-magic

--- a/src/images/embed.py
+++ b/src/images/embed.py
@@ -17,6 +17,7 @@
 """Embed pre-selected images in HTML source."""
 
 import logging
+import magic
 import os
 
 import bs4
@@ -24,12 +25,20 @@ import bs4
 import config
 
 logger = logging.getLogger('images.embed')
+mimetype = magic.Magic(mime=True)
 
 
 def image_is_embeddable(imgpath, imgsize):
     """Decide if given image will be embedded in HTML source."""
+    result = False
     _, ext = os.path.splitext(imgpath)
-    return ext.lower() == '.svg' and imgsize < 40960
+    if ext.lower() == '.svg' and imgsize < 40960:
+        # Do not assume an image is an SVG based only in file extension
+        if os.path.exists(imgpath):
+            mt = mimetype.from_file(imgpath)
+            if mt.startswith('image/svg'):
+                result = True
+    return result
 
 
 class _EmbedImages:

--- a/src/images/extract.py
+++ b/src/images/extract.py
@@ -252,6 +252,26 @@ class ImageParser:
             logger.warning("Unsupported image with GET args. Won't be included: %s", dsk_url)
             return None, None
 
+        # Make sure dsk_url lenght is below filesystem limit
+        limit = config.IMG_MAX_NAME_LEN
+        basedir, filename = os.path.split(dsk_url)
+        name, ext = os.path.splitext(filename)
+        if len(name) > limit:
+            # We cannot simply get the [:limit] part of the name, since we
+            # cannot know if we will have conflicts with other image names,
+            # so we'll split the filename into subfolders.
+            # superbigfilename.png would be super/bigfi/lename.png
+            logger.debug("Filename too long for %r", dsk_url)
+            new_split_name = list()
+            for i in range(int(len(name)/limit)+1):
+                new_part = name[i*limit:(i+1)*limit]
+                new_part.replace('.', '').replace('-', '').replace('/', '')
+                new_split_name.append(new_part)
+            new_dir = os.path.join(*new_split_name)
+            dsk_url = os.path.join(basedir,new_dir)
+            if ext:
+                dsk_url += ext
+
         logger.debug("web url: %r, dsk_url %r", web_url, dsk_url)
 
         # Replace the width and height by a querystring in the src of the image

--- a/src/images/scale.py
+++ b/src/images/scale.py
@@ -105,7 +105,7 @@ def run(verbose, src):
                 logger.debug("Rescaling to %d%% image %s", scale, dskurl)
             if scale == 100:
                 done_now[dskurl] = 100
-                if embed_enabled and image_is_embeddable(dskurl, imgsize):
+                if embed_enabled and image_is_embeddable(frompath, imgsize):
                     # don't copy image, leave it out of image blocks, it will
                     # be embedded from original location (without any reduction)
                     images_embed.add(dskurl)

--- a/src/scraping/css.py
+++ b/src/scraping/css.py
@@ -35,6 +35,7 @@ modules into a single file that will be loaded by all CDPedia pages.
 Reference: https://www.mediawiki.org/wiki/API:Styling_content
 """
 
+import html
 import logging
 import functools
 import os
@@ -163,7 +164,7 @@ class _CSSScraper:
 
         unique_names = set()
         for link in raw_links:
-            url = urllib.parse.urlparse(link)
+            url = urllib.parse.urlparse(html.unescape(link))
             query = dict(urllib.parse.parse_qsl(url.query))
             names = query.get('modules')
             if not names:

--- a/src/scraping/scraper.py
+++ b/src/scraping/scraper.py
@@ -130,10 +130,15 @@ def fetch_html(url):
         try:
             req = urllib.request.Request(url, headers=REQUEST_HEADERS)
             resp = urllib.request.urlopen(req, timeout=60)
-            compressedstream = io.BytesIO(resp.read())
+            resp_content = resp.read()
+            compressedstream = io.BytesIO(resp_content)
             gzipper = gzip.GzipFile(fileobj=compressedstream)
             html = gzipper.read().decode('utf-8')
             return html
+
+        except gzip.BadGzipFile:
+            # response content is uncompressed
+            return resp_content.decode('utf-8')
 
         except Exception as err:
             if isinstance(err, urllib.error.HTTPError) and err.code == 404:


### PR DESCRIPTION
@fzuccolo @facundobatista Acá van las mejoras que les comente en https://github.com/PyAr/CDPedia/pull/397

### Longitud maxima de archivo
Note que habia muchos errores de `OSError: [Errno 36] File name too long` por ejemplo con https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/%D0%9E%D1%81%D0%BD%D0%BE%D0%B2%D0%BD%D0%B8%D0%B9_%D0%BC%D0%BE%D1%82%D0%B8%D0%B2_%D0%BF%D0%B5%D1%87%D0%B0%D1%82%D0%BE%D0%BA_%D0%92%D1%96%D0%B9%D1%81%D1%8C%D0%BA%D0%B0_%D0%97%D0%B0%D0%BF%D0%BE%D1%80%D0%BE%D0%B6%D1%81%D1%8C%D0%BA%D0%BE%D0%B3%D0%BE_%D0%BD%D0%B8%D0%B7%D0%BE%D0%B2%D0%BE%D0%B3%D0%BE.png/30px-%D0%9E%D1%81%D0%BD%D0%BE%D0%B2%D0%BD%D0%B8%D0%B9_%D0%BC%D0%BE%D1%82%D0%B8%D0%B2_%D0%BF%D0%B5%D1%87%D0%B0%D1%82%D0%BE%D0%BA_%D0%92%D1%96%D0%B9%D1%81%D1%8C%D0%BA%D0%B0_%D0%97%D0%B0%D0%BF%D0%BE%D1%80%D0%BE%D0%B6%D1%81%D1%8C%D0%BA%D0%BE%D0%B3%D0%BE_%D0%BD%D0%B8%D0%B7%D0%BE%D0%B2%D0%BE%D0%B3%D0%BE.png que aparece en este articulo https://es.wikipedia.org/wiki/Organizaci%C3%B3n_territorial_de_Ucrania

Lo que hago es agarrar el nombre completo, y splitearlo en X subcarpetas de N longitud, donde N es un tamaño que se setea en el `config.py` actualmente en 240 caracteres

Como resultado, el archivo local es llamado `/images/commons/thumb/a/ab/30px-%25D0%259E%25D1%2581%25D0%25BD%25D0%25BE%25D0%25B2%25D0%25BD%25D0%25B8%25D0%25B9_%25D0%25BC%25D0%25BE%25D1%2582%25D0%25B8%25D0%25B2_%25D0%25BF%25D0%25B5%25D1%2587%25D0%25B0%25D1%2582%25D0%25BE%25D0%25BA_%25D0%2592%25D1%2596%25D0%25B9%25D1%2581%25D1%258C%25D0%25BA%25D0%25B0_%25D0%2597%25D0%25B0%25D0%25BF%25D0%25BE%25D1%2580%25D0%25BE%25D0%25B6%25D1%2581%25D1%258C%25D0%25BA%25D0%25BE%25D0/%25B3%25D0%25BE_%25D0%25BD%25D0%25B8%25D0%25B7%25D0%25BE%25D0%25B2%25D0%25BE%25D0%25B3%25D0%25BE.png` (hay una barra metida ahi al medio :P) de manera que el archivo puede ser incluido.

### No basarse unicamente en extension para saber si es SVG
En este articulo https://es.wikipedia.org/wiki/Artur_Chiling%C3%A1rov la firma tiene extension SVG, cuando en realidad es un PNG. Por este unico archivo, la ejecucion explotaba cuando intentaba hacer el embed. Lo que hice fue incluir `python-magic` como dependencia y a la hora de encontrar un archivo con extension SVG, realmente fijarse si es un SVG o no.